### PR TITLE
feature: add market table

### DIFF
--- a/app/api/v1/table/route.ts
+++ b/app/api/v1/table/route.ts
@@ -1,0 +1,49 @@
+import type { Market, MarketRequest } from "@/utils/types";
+
+import { marketRequest, marketSchema } from "@/validation/schema";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const body: MarketRequest = await req.json();
+  const bodyValidation = marketRequest.safeParse(body);
+
+  const { page, currency, fetchParam, fetchOrder } = body;
+
+  if (!bodyValidation.success) {
+    throw new Error("Failed to validate the request.");
+  }
+
+  const fetchHead = "https://api.coingecko.com/api/v3/coins/markets";
+  const fetchBody = `?vs_currency=${currency}&order=${fetchParam}_${fetchOrder}&per_page=50&page=${page}&sparkline=true&price_change_percentage=1h%2c24h%2c7d`;
+  const fetchTail = `&x_cg_demo_api_key=${process.env.COINGECKO_API_KEY}`;
+  const fetchURL = [fetchHead, fetchBody, fetchTail].join("");
+
+  let error: string | undefined;
+  const marketRes = await fetch(fetchURL, {
+    method: "GET",
+  }).catch((e) => (error = e));
+
+  if (error) {
+    throw new Error(error);
+  }
+  if (!marketRes.ok) {
+    throw new Error("The network response failed.");
+  }
+  const market = await marketRes.json();
+
+  // the coingecko api will return errors with this response format
+  // e.g. you are being throttled, the api key is invalid, etc.
+  if (market?.status?.error_message) {
+    throw new Error(market.status.error_message);
+  }
+
+  const marketValidation = marketSchema.safeParse(market);
+  if (!marketValidation.success) {
+    throw new Error("Failed to validate the market data.");
+  }
+
+  return NextResponse.json({
+    market: market as Market,
+    nextPage: body.page + 1,
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { Open_Sans as OpenSans } from "next/font/google";
 import "./globals.css";
 
-import NavBar from "./components/NavBar/NavBar";
+import NavBar from "@/components/NavBar/NavBar";
 import ProvidersMaster from "@/providers/ProvidersMaster";
 
 const openSans = OpenSans({ subsets: ["latin", "greek"] });
@@ -20,7 +20,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${openSans.className} dark:bg-grad-dark min-h-screen`}>
+      <body className={`${openSans.className} dark:bg-grad-dark min-h-screen overflow-y-scroll`}>
         <ProvidersMaster>
           <NavBar />
           {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,1 +1,11 @@
-export default function Home() {}
+import MarketTableMainWrapper from "@/components/MarketTable/MarketTableMainWrapper";
+
+export default function Home() {
+  return (
+    <main>
+      <div className="mt-8">
+        <MarketTableMainWrapper />
+      </div>
+    </main>
+  );
+}

--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/utils/cn";
 
 const Loader = ({ className }: { className?: string }) => (
-  <div role="status" className={cn("flex justify-center", className)}>
+  <div role="status" className={cn("flex justify-center mt-4 mb-12", className)}>
     <svg
       aria-hidden="true"
       className="w-8 h-8 dark:text-gray-600 fill-teal-500 animate-spin"

--- a/components/MarketTable/MarketTable.tsx
+++ b/components/MarketTable/MarketTable.tsx
@@ -1,0 +1,26 @@
+import type { Currency, MarketEleWithIdx } from "@/utils/types";
+
+import MarketTableBody from "./MarketTableBody";
+import MarketTableHeader from "./MarketTableHeader";
+
+type Props = {
+  data: MarketEleWithIdx[];
+
+  currency?: Currency;
+  initialIdx?: number;
+};
+
+const MarketTable = ({ data, currency, initialIdx }: Props) => {
+  return (
+    <table className="table-fixed border-separate border-spacing-y-1 text-foreground opacity-90">
+      <MarketTableHeader />
+      <MarketTableBody
+        data={data}
+        currency={currency}
+        initialIdx={initialIdx}
+      />
+    </table>
+  );
+};
+
+export default MarketTable;

--- a/components/MarketTable/MarketTable.tsx
+++ b/components/MarketTable/MarketTable.tsx
@@ -1,10 +1,10 @@
-import type { Currency, MarketEleWithIdx } from "@/utils/types";
+import type { Currency, MarketElementWithIdx } from "@/utils/types";
 
 import MarketTableBody from "./MarketTableBody";
 import MarketTableHeader from "./MarketTableHeader";
 
 type Props = {
-  data: MarketEleWithIdx[];
+  data: MarketElementWithIdx[];
 
   currency?: Currency;
   initialIdx?: number;

--- a/components/MarketTable/MarketTableBody.tsx
+++ b/components/MarketTable/MarketTableBody.tsx
@@ -1,0 +1,100 @@
+import type { Currency, MarketEleWithIdx } from "@/utils/types";
+
+import { formatLongName, formatSmallNum } from "@/utils/formatHelpers";
+
+import Image from "next/image";
+import MarketTablePriceChange from "./MarketTablePriceChange";
+import MarketTableProgressWidget from "./MarketTableProgressWidget";
+import MarketTableSparkline from "./MarketTableSparkline";
+import { default as TD } from "./MarketTableBodyCell";
+
+type Props = {
+  data: MarketEleWithIdx[];
+  currency?: Currency;
+  initialIdx?: number;
+};
+
+const MarketTableBody = ({ data, currency, initialIdx }: Props) => {
+  const isGaining = (n: number | null) => (n ?? 0) > 0;
+
+  return (
+    <tbody>
+      {data?.map(
+        ({
+          id,
+          name,
+          symbol,
+          called_index,
+          circulating_supply,
+          current_price,
+          market_cap,
+          total_supply,
+          total_volume,
+          image: imageURL,
+          price_change_percentage_1h_in_currency: change_1h,
+          price_change_percentage_24h_in_currency: change_24h,
+          price_change_percentage_7d_in_currency: change_7d,
+          sparkline_in_7d: { price: data_7d },
+        }) => (
+          <tr key={id} className="hover:dark:bg-slate-800/60">
+            <TD className="text-center border-l rounded-l-md">
+              {called_index + 1 + (initialIdx ?? 0)}
+            </TD>
+            <TD className="text-start">
+              <Image
+                className="inline mr-2"
+                src={imageURL.replace("large", "thumb")}
+                alt={`${name} logo`}
+                width={30}
+                height={30}
+                priority
+              />
+              <span>{formatLongName(name)}</span>{" "}
+              <span className="text-gray-400 text-sm uppercase font-semibold">
+                {symbol.trim()}
+              </span>
+            </TD>
+            <TD className="font-mono">
+              {currency || "$"}
+              {current_price < 0.01
+                ? formatSmallNum(current_price)
+                : current_price.toLocaleString("en-US")}
+            </TD>
+            <TD>
+              <MarketTablePriceChange change={change_1h} />
+            </TD>
+            <TD>
+              <MarketTablePriceChange change={change_24h} />
+            </TD>
+            <TD>
+              <MarketTablePriceChange change={change_7d} />
+            </TD>
+            <TD>
+              <MarketTableProgressWidget
+                leftNumber={total_volume}
+                rightNumber={market_cap}
+                isGaining={isGaining(change_7d)}
+              />
+            </TD>
+            <TD>
+              <MarketTableProgressWidget
+                leftNumber={circulating_supply}
+                rightNumber={total_supply}
+                isGaining={isGaining(change_7d)}
+              />
+            </TD>
+            <TD className="border-r rounded-r-md">
+              <MarketTableSparkline
+                data={data_7d}
+                id={id}
+                isGaining={isGaining(change_7d)}
+              />
+            </TD>
+          </tr>
+        )
+      )}
+    </tbody>
+  );
+};
+
+export default MarketTableBody;

--- a/components/MarketTable/MarketTableBody.tsx
+++ b/components/MarketTable/MarketTableBody.tsx
@@ -1,4 +1,4 @@
-import type { Currency, MarketEleWithIdx } from "@/utils/types";
+import type { Currency, MarketElementWithIdx } from "@/utils/types";
 
 import { formatLongName, formatSmallNum } from "@/utils/formatHelpers";
 
@@ -9,7 +9,7 @@ import MarketTableSparkline from "./MarketTableSparkline";
 import { default as TD } from "./MarketTableBodyCell";
 
 type Props = {
-  data: MarketEleWithIdx[];
+  data: MarketElementWithIdx[];
   currency?: Currency;
   initialIdx?: number;
 };

--- a/components/MarketTable/MarketTableBodyCell.tsx
+++ b/components/MarketTable/MarketTableBodyCell.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/utils/cn";
+
+type Props = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const MarketTableBodyCell = ({ children, className }: Props) => {
+  return (
+    <td
+      className={cn(
+        "h-16 py-1 border-y dark:border-neutral-700/60 dark:bg-neutral-800/60",
+        className
+      )}
+    >
+      {children}
+    </td>
+  );
+};
+
+export default MarketTableBodyCell;

--- a/components/MarketTable/MarketTableCaption.tsx
+++ b/components/MarketTable/MarketTableCaption.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { MarketFetchParam } from "@/utils/types";
+
+import { marketFetchParamMap } from "@/utils/maps";
+import {
+  useMarketTableCurrentPage,
+  useMarketTableNumFetchedPages,
+  useMarketTableMode,
+} from "@/hooks/useMarketTable";
+
+import { Coins as CoinsIcon } from "lucide-react";
+
+type Props = {
+  disablePreviousPage?: boolean;
+  disableNextPage?: boolean;
+  handleNextPage?: () => void;
+  handlePreviousPage?: () => void;
+};
+
+const MarketTableCaption = ({
+  disablePreviousPage,
+  disableNextPage,
+  handleNextPage,
+  handlePreviousPage,
+}: Props) => {
+  const tableMode = useMarketTableMode();
+  const fetchOrder: "asc" | "desc" = "desc";
+  const fetchParam: MarketFetchParam = "market_cap";
+
+  const currentPage = useMarketTableCurrentPage();
+  const totalPages = useMarketTableNumFetchedPages();
+
+  const handlePageDisplay = () => {
+    if (tableMode === "paginated") {
+      const range =
+        currentPage === 0
+          ? 50
+          : `${currentPage * 50 + 1}-${50 * (currentPage + 1)}`;
+      return fetchOrder === "desc" ? `top ${range}` : `bottom ${range}`;
+    } else {
+      const numRecords = totalPages * 50;
+      return fetchOrder === "desc"
+        ? `top ${numRecords}`
+        : `bottom ${numRecords}`;
+    }
+  };
+
+  return (
+    <div className="flex justify-between w-[1467px] pt-4 -mb-1 gap-x-2 rounded-t-xl dark:bg-zinc-900/70 dark:border-zinc-900/70 opacity-90 shadow-[0_-1px_2px_0_#404040]">
+      <div className="ml-6">
+        <span>
+          <CoinsIcon className="w-6 h-6 mr-2 -translate-y-1 inline" />
+        </span>
+        <span className="mr-2 text-2xl font-bold uppercase">
+          {handlePageDisplay()}
+        </span>
+        <span className="mr-2 text-lg text-gray-400 font-normal uppercase">
+          by
+        </span>
+        <span className="mr-2 text-lg text-gray-400 font-normal uppercase">
+          {marketFetchParamMap.get(fetchParam)}
+        </span>
+      </div>
+      {tableMode === "paginated" && (
+        <div className="flex gap-x-4 mr-4 text-sm font-medium">
+          <button
+            className="py-1 w-32 rounded-md dark:bg-teal-800 dark:disabled:bg-stone-800 disabled:text-primary/50 disabled:cursor-not-allowed"
+            disabled={disablePreviousPage}
+            onClick={handlePreviousPage}
+          >
+            Previous
+          </button>
+          <button
+            className="py-1 w-32 rounded-md dark:bg-teal-800 dark:disabled:bg-stone-800 disabled:text-primary/50 disabled:cursor-not-allowed"
+            disabled={disableNextPage}
+            onClick={handleNextPage}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MarketTableCaption;

--- a/components/MarketTable/MarketTableHeader.tsx
+++ b/components/MarketTable/MarketTableHeader.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import type { MarketTableSortField } from "@/utils/types";
+
+import { cn } from "@/utils/cn";
+import {
+  useMarketTableActions,
+  useMarketTableMode,
+  useMarketTableSortOrder,
+  useMarketTableSortField,
+} from "@/hooks/useMarketTable";
+
+import { ListFilter as ListFilterIcon } from "lucide-react";
+import { default as TH } from "./MarketTableHeaderCell";
+
+const MarketTableHeader = () => {
+  const sortActions = useMarketTableActions();
+  const sortOrder = useMarketTableSortOrder();
+  const sortSchema = useMarketTableSortField();
+  const tableMode = useMarketTableMode();
+
+  const isPaginated = tableMode === "paginated";
+  const isInfinite = tableMode === "infinite";
+
+  const handleSort = (schema: MarketTableSortField) => {
+    if (sortSchema === schema) {
+      sortActions.setPageSortOrder(sortOrder === "asc" ? "desc" : "asc");
+    } else {
+      sortActions.setPageSortField(schema);
+      sortActions.setPageSortOrder("desc");
+    }
+  };
+
+  return (
+    <thead>
+      <tr className="w-[1467px]">
+        <TH className="min-w-16 w-16 text-center rounded-bl-xl border-l">
+          <button
+            className={cn(isPaginated && "hover:dark:text-white")}
+            onClick={() => handleSort("called_index")}
+            disabled={isInfinite}
+          >
+            #
+          </button>
+        </TH>
+        <TH className="min-w-64">
+          <button
+            className={cn(isPaginated && "hover:dark:text-white")}
+            onClick={() => handleSort("name")}
+            disabled={isInfinite}
+          >
+            Name
+            {isPaginated && <ListFilterIcon className="w-3 h-3 ml-1 inline" />}
+          </button>
+        </TH>
+        <TH className="min-w-32">
+          <button
+            className={cn(isPaginated && "hover:dark:text-white")}
+            onClick={() => handleSort("current_price")}
+            disabled={isInfinite}
+          >
+            Price
+            {isPaginated && <ListFilterIcon className="w-3 h-3 ml-1 inline" />}
+          </button>
+        </TH>
+        <TH className="min-w-24">
+          <button
+            className={cn(isPaginated && "hover:dark:text-white")}
+            onClick={() => handleSort("price_change_percentage_1h_in_currency")}
+            disabled={isInfinite}
+          >
+            1h
+            {isPaginated && <ListFilterIcon className="w-3 h-3 ml-1 inline" />}
+          </button>
+        </TH>
+        <TH className="min-w-24">
+          <button
+            className={cn(isPaginated && "hover:dark:text-white")}
+            onClick={() =>
+              handleSort("price_change_percentage_24h_in_currency")
+            }
+            disabled={isInfinite}
+          >
+            24h
+            {isPaginated && <ListFilterIcon className="w-3 h-3 ml-1 inline" />}
+          </button>
+        </TH>
+        <TH className="min-w-24">
+          <button
+            className={cn(isPaginated && "hover:dark:text-white")}
+            onClick={() => handleSort("price_change_percentage_7d_in_currency")}
+            disabled={isInfinite}
+          >
+            7d
+            {isPaginated && <ListFilterIcon className="w-3 h-3 ml-1 inline" />}
+          </button>
+        </TH>
+        <TH className="min-w-64 indent-2">24h Vol / Market Cap</TH>
+        <TH className="min-w-64 indent-2">Circulating / Total Supply</TH>
+        <TH className="min-w-[218px] rounded-br-xl border-r indent-2">Last 7d</TH>
+      </tr>
+    </thead>
+  );
+};
+
+export default MarketTableHeader;

--- a/components/MarketTable/MarketTableHeaderCell.tsx
+++ b/components/MarketTable/MarketTableHeaderCell.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/utils/cn";
+
+type Props = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const MarketTableHeaderCell = ({ children, className }: Props) => {
+  return (
+    <th
+      scope="col"
+      className={cn(
+        "py-4 text-start text-sm border-b font-light tracking-wider dark:text-primary/80 dark:border-zinc-900/70 dark:bg-zinc-900/70",
+        className
+      )}
+    >
+      {children}
+    </th>
+  );
+};
+
+export default MarketTableHeaderCell;

--- a/components/MarketTable/MarketTableInfiniteWrapper.tsx
+++ b/components/MarketTable/MarketTableInfiniteWrapper.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import type { MarketQueryResult } from "@/utils/types";
+
+import { addMarketIndices } from "@/utils/addMarketIndices";
+import { marketTableSort } from "@/utils/marketTableSort";
+import { flatMarketRes } from "@/utils/flatMarketRes";
+import {
+  useMarketTableActions,
+  useMarketTableSortOrder,
+  useMarketTableSortField,
+} from "@/hooks/useMarketTable";
+
+import InfiniteScroll from "react-infinite-scroll-component";
+import Loader from "@/components/Loader";
+import MarketTable from "./MarketTable";
+import MarketTableCaption from "./MarketTableCaption";
+
+type Props = {
+  queryResult: MarketQueryResult;
+};
+
+const MarketTableInfiniteWrapper = ({
+  queryResult: { data, error, isPending, isFetching, fetchNextPage },
+}: Props) => {
+  const { setNumFetchedPages: setTotalPages } = useMarketTableActions();
+  setTotalPages(data?.pages.length ?? 0);
+
+  const sortOrder = useMarketTableSortOrder();
+  const sortField = useMarketTableSortField();
+
+  const tableData = flatMarketRes(data?.pages) || [];
+  const indexedData = addMarketIndices(tableData);
+  const sortedData = marketTableSort(indexedData, sortField, sortOrder);
+
+  const showLoader = !error && (isPending || isFetching);
+
+  /**
+   * Using the loader prop of the InfiniteScroll component
+   * creates a second scrollbar nested within the table;
+   * to avoid this handle loading below the component.
+   */
+  return (
+    <div>
+      <div className="flex flex-col items-center">
+        <MarketTableCaption />
+        <InfiniteScroll
+          dataLength={tableData?.length || 0}
+          next={fetchNextPage}
+          hasMore={!data?.pages?.length || data.pages.length < 10}
+          loader={<></>}
+          endMessage={<p>End of list.</p>}
+        >
+          <div className="flex flex-col">
+            <MarketTable data={sortedData} />
+          </div>
+        </InfiniteScroll>
+        {showLoader && <Loader />}
+        {error && (
+          <p className="mt-4">An unexpected error occurred: {error.message}</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MarketTableInfiniteWrapper;

--- a/components/MarketTable/MarketTableMainWrapper.tsx
+++ b/components/MarketTable/MarketTableMainWrapper.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useMarketTableMode } from "@/hooks/useMarketTable";
+import { useMarketQuery } from "@/hooks/useMarketQuery";
+
+import { ErrorBoundary } from "react-error-boundary";
+import MarketTableInfiniteWrapper from "./MarketTableInfiniteWrapper";
+import MarketTablePaginatedWrapper from "./MarketTablePaginatedWrapper";
+import MarketTableSwapMode from "./MarketTableSwapMode";
+
+const MarketTableMainWrapper = () => {
+  const tableMode = useMarketTableMode();
+
+  // TODO: get the three fields below from url search params
+  const currency = "usd";
+  const marketFetchParam = "market_cap";
+  const marketFetchOrder = "desc";
+
+  const queryResult = useMarketQuery(
+    currency,
+    marketFetchParam,
+    marketFetchOrder
+  );
+
+  return (
+    <div>
+      <MarketTableSwapMode />
+      <ErrorBoundary
+        fallback={
+          <h2 className="text-center text-2xl text-destructive">
+            Failed to render market data.
+          </h2>
+        }
+      >
+        {tableMode === "paginated" ? (
+          <MarketTablePaginatedWrapper queryResult={queryResult} />
+        ) : (
+          <MarketTableInfiniteWrapper queryResult={queryResult} />
+        )}
+      </ErrorBoundary>
+    </div>
+  );
+};
+
+export default MarketTableMainWrapper;

--- a/components/MarketTable/MarketTablePaginatedWrapper.tsx
+++ b/components/MarketTable/MarketTablePaginatedWrapper.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import type { MarketQueryResult } from "@/utils/types";
+
+import { addMarketIndices } from "@/utils/addMarketIndices";
+import { marketTableSort } from "@/utils/marketTableSort";
+import {
+  useMarketTableActions,
+  useMarketTableCurrentPage,
+  useMarketTableSortOrder,
+  useMarketTableSortField,
+} from "@/hooks/useMarketTable";
+
+import {
+  ChevronLeft as ChevronLeftIcon,
+  ChevronRight as ChevronRightIcon,
+} from "lucide-react";
+import Loader from "../Loader";
+import MarketTable from "./MarketTable";
+import MarketTableCaption from "./MarketTableCaption";
+
+type Props = {
+  queryResult: MarketQueryResult;
+};
+
+const MarketTablePaginatedWrapper = ({
+  queryResult: {
+    data,
+    error,
+    isPending,
+    isFetching,
+    isRefetching,
+    fetchNextPage,
+  },
+}: Props) => {
+  const currentPage = useMarketTableCurrentPage();
+  const { setCurrentPage } = useMarketTableActions();
+  const sortOrder = useMarketTableSortOrder();
+  const sortField = useMarketTableSortField();
+
+  const tableData = data?.pages[currentPage]?.market || [];
+  const indexedData = addMarketIndices(tableData);
+  const sortedData = marketTableSort(indexedData, sortField, sortOrder);
+
+  const showLoader = !error && (isPending || isFetching);
+
+  const disableNextPage = !isRefetching && (isPending || isFetching);
+  const disablePreviousPage = disableNextPage || currentPage === 0;
+
+  const handleNextPage = () => {
+    if (data && data.pages.length <= currentPage + 1) {
+      fetchNextPage();
+    }
+    setCurrentPage(currentPage + 1);
+  };
+
+  const handlePreviousPage = () => {
+    if (currentPage !== 0) {
+      setCurrentPage(currentPage - 1);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex flex-col items-center mb-12">
+        <MarketTableCaption
+          disableNextPage={disableNextPage}
+          disablePreviousPage={disablePreviousPage}
+          handleNextPage={handleNextPage}
+          handlePreviousPage={handlePreviousPage}
+        />
+        <MarketTable data={sortedData} initialIdx={50 * currentPage} />
+        {!isFetching && (
+          <div className="flex justify-center mt-4 gap-x-4">
+            <button
+              className="px-3 py-3 border rounded-lg hover:dark:bg-muted disabled:dark:cursor-not-allowed"
+              onClick={() => {
+                window.scrollTo(0, 0);
+                handlePreviousPage();
+              }}
+              disabled={disablePreviousPage}
+            >
+              <ChevronLeftIcon className="w-4 h-4" />
+            </button>
+            <button
+              className="px-3 py-3 border rounded-lg hover:dark:bg-muted disabled:dark:cursor-not-allowed"
+              onClick={() => {
+                window.scrollTo(0, 0);
+                handleNextPage();
+              }}
+              disabled={disableNextPage}
+            >
+              <ChevronRightIcon className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+        {showLoader && <Loader />}
+        {error && <p>An unexpected error occurred: {error.message}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default MarketTablePaginatedWrapper;

--- a/components/MarketTable/MarketTablePriceChange.tsx
+++ b/components/MarketTable/MarketTablePriceChange.tsx
@@ -1,0 +1,24 @@
+import { padTwoDecimals, roundDigits } from "@/utils/formatHelpers";
+
+import CaretIcon from "../../Icons/Caret";
+
+const MarketTablePriceChange = ({ change }: { change: number | null }) => {
+  const formattedChange = (n: number) =>
+    padTwoDecimals(roundDigits(n, 2).toString());
+
+  if (!change)
+    return <span className="text-xs text-muted-foreground">N/A</span>;
+  return change < 0 ? (
+    <span className="text-market-down font-mono">
+      <CaretIcon className="w-3 h-3 mr-1 rotate-180 inline fill-market-down" />
+      {formattedChange(change)}%
+    </span>
+  ) : (
+    <span className="text-market-up font-mono">
+      <CaretIcon className="w-3 h-3 mr-1 inline fill-market-up" />
+      {formattedChange(change)}%
+    </span>
+  );
+};
+
+export default MarketTablePriceChange;

--- a/components/MarketTable/MarketTableProgressWidget.tsx
+++ b/components/MarketTable/MarketTableProgressWidget.tsx
@@ -1,0 +1,73 @@
+import { cn } from "@/utils/cn";
+import { currencyMap } from "@/utils/maps";
+
+import { Circle as CircleIcon, Infinity as InfinityIcon } from "lucide-react";
+
+type Props = {
+  rightNumber: number | null;
+  leftNumber: number | null;
+  isGaining: boolean;
+};
+
+const MarketTableProgressWidget = ({
+  leftNumber,
+  rightNumber,
+  isGaining,
+}: Props) => {
+  const currency = "usd";
+
+  const percentFull = () => {
+    if (leftNumber && rightNumber) {
+      return leftNumber / rightNumber;
+    } else return 0;
+  };
+
+  const formatNumber = (n: number | null) => {
+    return n ? (
+      currencyMap.get(currency) +
+        Intl.NumberFormat("en-US", {
+          notation: "compact",
+          maximumFractionDigits: 1,
+        }).format(n)
+    ) : (
+      <InfinityIcon className="w-4 h-4 inline" />
+    );
+  };
+
+  return (
+    <div className="flex flex-col justify-center items-start">
+      <div className="w-[80%] px-2 flex justify-between text-sm">
+        <span>
+          <CircleIcon
+            className={cn(
+              "h-[6px] w-[6px] mr-2 inline",
+              isGaining
+                ? "fill-market-teal text-market-teal"
+                : "fill-market-down text-market-down"
+            )}
+          />
+          <span className="font-mono">{formatNumber(leftNumber)}</span>
+        </span>
+        <span>
+          <CircleIcon className="h-[6px] w-[6px] mr-2 fill-paynes-gray text-paynes-gray inline" />
+          <span className="font-mono">{formatNumber(rightNumber)}</span>
+        </span>
+      </div>
+      <div className="rounded-[3px] w-56 h-[6px] bg-paynes-gray">
+        <div
+          className={cn(
+            "rounded-[3px] w-full h-[6px]",
+            isGaining ? "bg-market-teal" : "bg-market-down"
+          )}
+          style={{
+            width: `min(calc(100% * ${
+              percentFull() < 0.02 ? 0.02 : percentFull()
+            }), 100%)`,
+          }}
+        ></div>
+      </div>
+    </div>
+  );
+};
+
+export default MarketTableProgressWidget;

--- a/components/MarketTable/MarketTableSparkline.tsx
+++ b/components/MarketTable/MarketTableSparkline.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type { ChartData } from "chart.js";
+
+import { consecutiveArray } from "@/utils/arrayHelpers";
+import {
+  sparklineColor,
+  sparklineOptions,
+  sparklineGradient,
+} from "@/utils/sparklineHelpers";
+import { useInView } from "framer-motion";
+import { useRef } from "react";
+
+import {
+  Chart as ChartJS,
+  Filler,
+  LineElement,
+  PointElement,
+} from "chart.js/auto";
+import { ErrorBoundary } from "react-error-boundary";
+import { Line } from "react-chartjs-2";
+
+ChartJS.register(Filler, LineElement, PointElement);
+
+type Props = {
+  data: number[];
+  id: string;
+  isGaining: boolean;
+};
+
+const MarketTableSparkline = ({ data, id, isGaining }: Props) => {
+  // only render charts if they've actually been in view
+  const viewRef = useRef<HTMLDivElement>(null);
+  const isInView = useInView(viewRef, { once: true });
+
+  // length is 56 so be sure to include the last point (which isn't divisible by 3)
+  const efficientData = [
+    ...data.filter((_, idx) => idx % 3 === 0),
+    data[data.length - 1],
+  ];
+
+  const chartData: ChartData<"line"> = {
+    labels: consecutiveArray(efficientData.length),
+    datasets: [
+      {
+        label: id,
+        data: efficientData,
+        borderColor: sparklineColor(isGaining),
+        backgroundColor: (context) => {
+          const gradient = context.chart.ctx.createLinearGradient(0, 0, 0, 100);
+          return sparklineGradient(isGaining, gradient);
+        },
+        fill: true,
+        tension: 0.5,
+      },
+    ],
+  };
+
+  return (
+    <ErrorBoundary
+      fallback={
+        <p className="text-sm text-center text-destructive">
+          failed to render sparkline.
+        </p>
+      }
+    >
+      <div className="mr-6">
+        <div className="w-48 h-16" ref={viewRef}>
+          {isInView && <Line data={chartData} options={sparklineOptions} />}
+        </div>
+      </div>
+    </ErrorBoundary>
+  );
+};
+
+export default MarketTableSparkline;

--- a/components/MarketTable/MarketTableSwapMode.tsx
+++ b/components/MarketTable/MarketTableSwapMode.tsx
@@ -1,0 +1,37 @@
+import { useMarketTableMode } from "@/hooks/useMarketTable";
+import { useMarketTableActions } from "@/hooks/useMarketTable";
+
+const MarketTableSwapMode = () => {
+  const tableMode = useMarketTableMode();
+  const { setPageSortOrder, setPageSortField, setMarketTableMode } =
+    useMarketTableActions();
+
+  const handleTableMode = () => {
+    if (tableMode === "infinite") {
+      setMarketTableMode("paginated");
+    } else {
+      /**
+       * Be sure to re-sort the entries to their numerically fetched order
+       * when switching to infinite table mode.
+       * If this is not done, when a new page is fetched via scrolling
+       * it will cause new entries to pop in both above and below.
+       */
+      setPageSortField("called_index");
+      setPageSortOrder("asc");
+      setMarketTableMode("infinite");
+    }
+  };
+
+  return (
+    <div className="flex justify-end mb-2">
+      <button
+        className="px-3 py-2 mr-56 hover:bg-muted/70 rounded-md text-sm text-primary/70 font-light transition-colors"
+        onClick={handleTableMode}
+      >
+        Swap View
+      </button>
+    </div>
+  );
+};
+
+export default MarketTableSwapMode;

--- a/components/MarketTable/NoFetch/SampleMarketTable.tsx
+++ b/components/MarketTable/NoFetch/SampleMarketTable.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { addMarketIndices } from "@/utils/addMarketIndices";
+import { marketTableSort } from "@/utils/marketTableSort";
+import { sampleMarketTable } from "@/utils/dummyData/sampleMarketTable";
+import {
+  useMarketTableSortField,
+  useMarketTableSortOrder,
+} from "@/hooks/useMarketTable";
+
+import MarketTable from "../MarketTable";
+import MarketTableCaption from "../MarketTableCaption";
+
+/**
+ * Use this component to view an example table without needing to actually fetch any data.
+ */
+const SampleMarketTable = () => {
+  const sortOrder = useMarketTableSortOrder();
+  const sortSchema = useMarketTableSortField();
+  const sampleDataWithIdx = addMarketIndices(sampleMarketTable);
+  const sortedData = marketTableSort(sampleDataWithIdx, sortSchema, sortOrder);
+
+  return (
+    <div>
+      <div className="flex flex-col items-center mb-12">
+        <MarketTableCaption
+          handleNextPage={() => null}
+          handlePreviousPage={() => null}
+          disableNextPage={true}
+          disablePreviousPage={true}
+        />
+        <MarketTable data={sortedData} initialIdx={0} />
+      </div>
+    </div>
+  );
+};
+
+export default SampleMarketTable;

--- a/hooks/useMarketQuery.ts
+++ b/hooks/useMarketQuery.ts
@@ -1,0 +1,35 @@
+import type {
+  Currency,
+  MarketRequest,
+  MarketFetchParam,
+  MarketResponse,
+} from "@/utils/types";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+export const useMarketQuery = (
+  currency: Currency,
+  fetchParam: MarketFetchParam,
+  fetchOrder: "asc" | "desc"
+) => {
+  return useInfiniteQuery({
+    // unique keys will create independent caches so unrelated data is not mixed together
+    queryKey: ["market", fetchParam, fetchOrder],
+
+    // all pages are refetched to avoid updates that can cause duplication issues
+    staleTime: 300 * 1000,
+
+    queryFn: async ({ pageParam }): Promise<MarketResponse> =>
+      await fetch("http://localhost:3000/api/v1/table", {
+        method: "POST",
+        body: JSON.stringify(<MarketRequest>{
+          page: pageParam,
+          currency: currency,
+          fetchParam: fetchParam,
+          fetchOrder: fetchOrder,
+        }),
+      }).then((res) => res.json()),
+    initialPageParam: 1,
+    getNextPageParam: (prev) => prev.nextPage,
+  });
+};

--- a/hooks/useMarketTable.ts
+++ b/hooks/useMarketTable.ts
@@ -1,0 +1,74 @@
+import type { MarketTableSortField, MarketTableMode } from "@/utils/types";
+
+import { create } from "zustand";
+
+type MarketTableState = {
+  currentPage: number;
+  numFetchedPages: number;
+
+  marketMode: MarketTableMode;
+  sortOrder: "asc" | "desc";
+  sortField: MarketTableSortField;
+
+  actions: MarketTableAction;
+};
+
+type MarketTableAction = {
+  setCurrentPage: (page: MarketTableState["currentPage"]) => void;
+  setNumFetchedPages: (n: MarketTableState["numFetchedPages"]) => void;
+
+  setMarketTableMode: (mode: MarketTableState["marketMode"]) => void;
+  setPageSortOrder: (order: MarketTableState["sortOrder"]) => void;
+  setPageSortField: (schema: MarketTableState["sortField"]) => void;
+};
+
+const useMarketTableStore = create<MarketTableState>((set) => ({
+  currentPage: 0,
+  numFetchedPages: 0,
+
+  marketMode: "paginated",
+  sortOrder: "desc",
+  sortField: "market_cap",
+
+  actions: {
+    setCurrentPage: (page) => set(() => ({ currentPage: page })),
+    setNumFetchedPages: (n) => set(() => ({ numFetchedPages: n })),
+
+    setMarketTableMode: (mode) => set(() => ({ marketMode: mode })),
+    setPageSortField: (schema) => set(() => ({ sortField: schema })),
+    setPageSortOrder: (order) => set(() => ({ sortOrder: order })),
+  },
+}));
+
+/**
+ * Export fields individually to avoid subscribing to the entire store.
+ * Subscribing to the the entire store will trigger a re-render for every change,
+ * even ones the component does not need to know about.
+ *
+ * e.g. I have a component above the market table that only relies on the current page.
+ * If I subscribe to the entire store, this component will be re-rendered whenever the table mode
+ * is changed despite not depending on that property.
+ *
+ * Actions are static and can be exported in a single bundle without impacting performance.
+ *
+ * https://tkdodo.eu/blog/working-with-zustand
+ */
+export const useMarketTableCurrentPage = () => {
+  return useMarketTableStore((state) => state.currentPage);
+};
+export const useMarketTableNumFetchedPages = () => {
+  return useMarketTableStore((state) => state.numFetchedPages);
+};
+export const useMarketTableMode = () => {
+  return useMarketTableStore((state) => state.marketMode);
+};
+export const useMarketTableSortField = () => {
+  return useMarketTableStore((state) => state.sortField);
+};
+export const useMarketTableSortOrder = () => {
+  return useMarketTableStore((state) => state.sortOrder);
+};
+
+export const useMarketTableActions = () => {
+  return useMarketTableStore((state) => state.actions);
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**.coingecko.com",
+        port: "",
+        pathname: "/coins/images/**",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/utils/addMarketIndices.ts
+++ b/utils/addMarketIndices.ts
@@ -1,4 +1,4 @@
-import type { MarketEleNoIdx, MarketEleWithIdx } from "./types";
+import type { MarketElementNoIdx, MarketElementWithIdx } from "./types";
 
 /**
  * Incorporate the originally fetched index into the data rendered by the table.
@@ -10,9 +10,9 @@ import type { MarketEleNoIdx, MarketEleWithIdx } from "./types";
  * This method allows for the index shown to the left of the name to still be preserved as #1.
  * The added property is displayed in the '#' column of the table.
  */
-export function addMarketIndices(data: MarketEleNoIdx[]) {
-  return data.reduce((extended: MarketEleWithIdx[], ele, idx) => {
-    const extendedEle = { ...ele, called_index: idx };
-    return [...extended, extendedEle];
+export function addMarketIndices(marketData: MarketElementNoIdx[]) {
+  return marketData.reduce((extendedData: MarketElementWithIdx[], element, idx) => {
+    const elementWithIdx = { ...element, called_index: idx };
+    return [...extendedData, elementWithIdx];
   }, []);
 }

--- a/utils/addMarketIndices.ts
+++ b/utils/addMarketIndices.ts
@@ -1,0 +1,18 @@
+import type { MarketEleNoIdx, MarketEleWithIdx } from "./types";
+
+/**
+ * Incorporate the originally fetched index into the data rendered by the table.
+ *
+ * Consider: if I fetch the top 50 coins by market cap Bitcoin will (most likely)
+ * be at the #1 spot on top of the table.
+ * If I then sort the data by name Bitcoin will no longer be at the very top, but I would still like
+ * to know that it has the highest market cap.
+ * This method allows for the index shown to the left of the name to still be preserved as #1.
+ * The added property is displayed in the '#' column of the table.
+ */
+export function addMarketIndices(data: MarketEleNoIdx[]) {
+  return data.reduce((extended: MarketEleWithIdx[], ele, idx) => {
+    const extendedEle = { ...ele, called_index: idx };
+    return [...extended, extendedEle];
+  }, []);
+}

--- a/utils/arrayHelpers.ts
+++ b/utils/arrayHelpers.ts
@@ -1,0 +1,28 @@
+/**
+ * Creates an array of the specified length full of the value n.
+ */
+export function arrayOfNs(len: number, n: number = 0) {
+  const result = [];
+  for (let i = 0; i < len; i++) {
+    result.push(n);
+  }
+  return result;
+}
+
+/**
+ * Creates a dummy array of the specified length.
+ */
+export function arrayOfSize(len: number) {
+  return Array.from(Array(len)).fill(NaN);
+}
+
+/**
+ * Creates an array of consecutively increasing integers, starting from the begin param (or 0 if this is not specified).
+ */
+export function consecutiveArray(n: number, begin: number = 0) {
+  let result = [];
+  for (let i = 0; i < n; i++) {
+    result.push(i + begin);
+  }
+  return result;
+}

--- a/utils/flatMarketRes.ts
+++ b/utils/flatMarketRes.ts
@@ -1,0 +1,9 @@
+import type { MarketResponse } from "./types";
+
+/**
+ * Removes the pagination information from the InfiniteQueryResponse,
+ * transforming the input to a 1-Dimensional array of only table rows to map over.
+ */
+export function flatMarketRes(res: MarketResponse[] | undefined) {
+  return res?.map((ele) => ele.market).flat();
+}

--- a/utils/formatHelpers.ts
+++ b/utils/formatHelpers.ts
@@ -1,0 +1,39 @@
+/**
+ * Shortens very long coin names that will cause styling issues in the market table.
+ */
+export function formatLongName(name: string) {
+  const maxLen = 18;
+
+  if (name.length >= maxLen) {
+    return name.slice(0, 14).trim() + "...";
+  } else {
+    return name;
+  }
+}
+
+/**
+ * Saves table space by using scientific notation for very small numbers.
+ * e.g. 0.000001 -> 1e-6
+ */
+export function formatSmallNum(n: number): string {
+  return n < 0.001 ? n.toExponential(2) : n.toString();
+}
+
+/**
+ * Used so percentage changes or currency will have two numbers after the decimal.
+ * e.g. 10.2% -> 10.20%
+ */
+export function padTwoDecimals(input: string) {
+  const [beforeDecimal, afterDecimal] = input.split(".");
+
+  if (!afterDecimal) return `${beforeDecimal}.00`;
+  else return `${beforeDecimal}.${afterDecimal.padEnd(2, "0")}`;
+}
+
+/**
+ * Rounds the input to the specified number of digits.
+ */
+export function roundDigits(n: number, numDigits: number): number {
+  const tenPow = 10 ** numDigits;
+  return Math.abs(Math.round(n * tenPow) / tenPow);
+}

--- a/utils/maps.ts
+++ b/utils/maps.ts
@@ -1,0 +1,14 @@
+import { MarketFetchParam, type Currency } from "./types";
+
+export const currencyMap = new Map<Currency, string>([
+  ["usd", "$"],
+  ["eur", "€"],
+  ["gbp", "£"],
+  ["btc", "฿"],
+  ["eth", "Ξ"],
+]);
+
+export const marketFetchParamMap = new Map<MarketFetchParam, string>([
+  ["market_cap", "market cap"],
+  ["volume", "volume"],
+]);

--- a/utils/marketTableSort.ts
+++ b/utils/marketTableSort.ts
@@ -1,0 +1,19 @@
+import type { MarketEleWithIdx, MarketTableSortField } from "./types";
+
+import { sort } from "fast-sort";
+
+export function marketTableSort(
+  data: MarketEleWithIdx[] | undefined,
+  sortBy: MarketTableSortField,
+  order: "asc" | "desc"
+) {
+  if (!data) return [];
+
+  const handleOrder = (by: MarketTableSortField) => {
+    return order === "asc"
+      ? sort(data).by([{ asc: (ele) => ele[by] }, { asc: (ele) => ele.id }])
+      : sort(data).by([{ desc: (ele) => ele[by] }, { asc: (ele) => ele.id }]);
+  };
+
+  return handleOrder(sortBy);
+}

--- a/utils/marketTableSort.ts
+++ b/utils/marketTableSort.ts
@@ -1,9 +1,9 @@
-import type { MarketEleWithIdx, MarketTableSortField } from "./types";
+import type { MarketElementWithIdx, MarketTableSortField } from "./types";
 
 import { sort } from "fast-sort";
 
 export function marketTableSort(
-  data: MarketEleWithIdx[] | undefined,
+  data: MarketElementWithIdx[] | undefined,
   sortBy: MarketTableSortField,
   order: "asc" | "desc"
 ) {

--- a/utils/sparklineHelpers.ts
+++ b/utils/sparklineHelpers.ts
@@ -1,0 +1,53 @@
+import type { ChartOptions } from "chart.js";
+
+export function sparklineColor(isGaining: boolean) {
+  return isGaining ? "#43FFDD" : "#F23F8A";
+}
+
+export function sparklineGradient(
+  isGaining: boolean,
+  gradient: CanvasGradient
+) {
+  if (isGaining) {
+    gradient.addColorStop(0, "rgba(20, 155, 20, 0.4)");
+    gradient.addColorStop(0.6, "rgba(38, 38, 38, 0.0)");
+  } else {
+    gradient.addColorStop(0, "rgba(255, 99, 132, 0.4");
+    gradient.addColorStop(0.6, "rgba(38, 38, 38, 0.0)");
+  }
+  return gradient;
+}
+
+export const sparklineOptions: ChartOptions<"line"> = {
+  elements: {
+    line: {
+      borderWidth: 2,
+    },
+    point: {
+      radius: 0,
+      hoverRadius: 0,
+    },
+  },
+  events: [],
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      display: false,
+    },
+    title: {
+      display: false,
+    },
+    tooltip: {
+      enabled: false,
+    },
+  },
+  responsive: true,
+  scales: {
+    x: {
+      display: false,
+    },
+    y: {
+      display: false,
+    },
+  },
+};

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,0 +1,41 @@
+import type {
+  InfiniteData,
+  UseInfiniteQueryResult,
+} from "@tanstack/react-query";
+
+import {
+  marketSchema,
+  marketResponseSchema,
+  marketRequest,
+  marketEleNoIdxSchema,
+  marketEleWithIdxSchema,
+  marketFetchParamSchema,
+} from "@/validation/schema";
+import { z } from "zod";
+
+const validCurrencies = ["usd", "eur", "gbp", "btc", "eth"] as const;
+export type Currency = (typeof validCurrencies)[number];
+
+export type Market = z.infer<typeof marketSchema>;
+export type MarketEleNoIdx = z.infer<typeof marketEleNoIdxSchema>;
+export type MarketEleWithIdx = z.infer<typeof marketEleWithIdxSchema>;
+export type MarketFetchParam = z.infer<typeof marketFetchParamSchema>;
+export type MarketTableMode = "infinite" | "paginated";
+export type MarketResponse = z.infer<typeof marketResponseSchema>;
+export type MarketRequest = z.infer<typeof marketRequest>;
+
+const marketTableSortFields = [
+  "name",
+  "called_index",
+  "current_price",
+  "market_cap",
+  "price_change_percentage_1h_in_currency",
+  "price_change_percentage_24h_in_currency",
+  "price_change_percentage_7d_in_currency",
+] as const;
+export type MarketTableSortField = (typeof marketTableSortFields)[number];
+
+export type MarketQueryResult = UseInfiniteQueryResult<
+  InfiniteData<MarketResponse, unknown>,
+  Error
+>;

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -7,8 +7,8 @@ import {
   marketSchema,
   marketResponseSchema,
   marketRequest,
-  marketEleNoIdxSchema,
-  marketEleWithIdxSchema,
+  marketElementNoIdxSchema,
+  marketElementWithIdxSchema,
   marketFetchParamSchema,
 } from "@/validation/schema";
 import { z } from "zod";
@@ -17,8 +17,8 @@ const validCurrencies = ["usd", "eur", "gbp", "btc", "eth"] as const;
 export type Currency = (typeof validCurrencies)[number];
 
 export type Market = z.infer<typeof marketSchema>;
-export type MarketEleNoIdx = z.infer<typeof marketEleNoIdxSchema>;
-export type MarketEleWithIdx = z.infer<typeof marketEleWithIdxSchema>;
+export type MarketElementNoIdx = z.infer<typeof marketElementNoIdxSchema>;
+export type MarketElementWithIdx = z.infer<typeof marketElementWithIdxSchema>;
 export type MarketFetchParam = z.infer<typeof marketFetchParamSchema>;
 export type MarketTableMode = "infinite" | "paginated";
 export type MarketResponse = z.infer<typeof marketResponseSchema>;

--- a/validation/schema.ts
+++ b/validation/schema.ts
@@ -20,7 +20,7 @@ export const marketRequest = z.object({
   fetchOrder: z.union([z.literal("asc"), z.literal("desc")]),
 });
 
-export const marketEleNoIdxSchema = z.object({
+export const marketElementNoIdxSchema = z.object({
   id: z.string(),
   symbol: z.string(),
   name: z.string(),
@@ -64,11 +64,11 @@ export const marketEleNoIdxSchema = z.object({
   price_change_percentage_7d_in_currency: z.number().nullable(),
 });
 
-export const marketEleWithIdxSchema = marketEleNoIdxSchema.extend({
+export const marketElementWithIdxSchema = marketElementNoIdxSchema.extend({
   called_index: z.number(),
 });
 
-export const marketSchema = z.array(marketEleNoIdxSchema);
+export const marketSchema = z.array(marketElementNoIdxSchema);
 export const marketResponseSchema = z.object({
   market: marketSchema,
   nextPage: z.number(),

--- a/validation/schema.ts
+++ b/validation/schema.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+export const validCurrenciesSchema = z.union([
+  z.literal("usd"),
+  z.literal("eur"),
+  z.literal("gbp"),
+  z.literal("btc"),
+  z.literal("eth"),
+]);
+
+export const marketFetchParamSchema = z.union([
+  z.literal("market_cap"),
+  z.literal("volume"),
+]);
+
+export const marketRequest = z.object({
+  page: z.number(),
+  currency: validCurrenciesSchema,
+  fetchParam: marketFetchParamSchema,
+  fetchOrder: z.union([z.literal("asc"), z.literal("desc")]),
+});
+
+export const marketEleNoIdxSchema = z.object({
+  id: z.string(),
+  symbol: z.string(),
+  name: z.string(),
+  image: z.string(),
+
+  current_price: z.number(),
+  market_cap: z.number(),
+  market_cap_rank: z.number().nullable(),
+  fully_diluted_valuation: z.number().nullable(),
+  total_volume: z.number(),
+  high_24h: z.number(),
+  low_24h: z.number(),
+  price_change_24h: z.number(),
+  price_change_percentage_24h: z.number(),
+  market_cap_change_24h: z.number(),
+  market_cap_change_percentage_24h: z.number(),
+  circulating_supply: z.number(),
+  total_supply: z.number().nullable(),
+  max_supply: z.number().nullable(),
+
+  ath: z.number(),
+  ath_change_percentage: z.number(),
+  ath_date: z.string(),
+  atl: z.number(),
+  atl_change_percentage: z.number(),
+  atl_date: z.string(),
+  roi: z
+    .object({
+      times: z.number(),
+      currency: z.string(),
+      percentage: z.number(),
+    })
+    .nullable(),
+  last_updated: z.string(),
+
+  sparkline_in_7d: z.object({
+    price: z.number().array(),
+  }),
+  price_change_percentage_1h_in_currency: z.number().nullable(),
+  price_change_percentage_24h_in_currency: z.number().nullable(),
+  price_change_percentage_7d_in_currency: z.number().nullable(),
+});
+
+export const marketEleWithIdxSchema = marketEleNoIdxSchema.extend({
+  called_index: z.number(),
+});
+
+export const marketSchema = z.array(marketEleNoIdxSchema);
+export const marketResponseSchema = z.object({
+  market: marketSchema,
+  nextPage: z.number(),
+});


### PR DESCRIPTION
This PR adds a market overview table.

- The table is currently non-responsive and only has explicit theming for dark mode.
- Users can switch between a paginated and infinite view mode.
- Sparklines are only rendered once they first come into view.
- Market data is fetched server-side, preventing the user from seeing the API key.


https://github.com/agreen254/crypto-app/assets/101513222/4933ada9-c3e0-4510-b525-6e07c495c262

