### PR TITLE
Overlap Bar Chart

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,6 @@ import { useMarketQuery } from "@/hooks/useMarketQuery";
 import CarouselWrapper from "@/components/Carousel/CarouselWrapper";
 import ComparisonChartsWrapper from "@/components/ComparisonCharts/ComparisonChartsWrapper";
 import MarketTableMainWrapper from "@/components/MarketTable/MarketTableMainWrapper";
-import SampleErrorToast from "@/components/Toast/SampleErrorToast";
 
 export default function Home() {
   // TODO: get the three fields below from url search params
@@ -21,7 +20,6 @@ export default function Home() {
 
   return (
     <main className="flex flex-col items-center gap-y-4">
-      <SampleErrorToast />
       <CarouselWrapper axis="x" queryResult={queryResult} />
       <div className="flex justify-between w-table-xl gap-x-12">
         <ComparisonChartsWrapper />

--- a/components/ComparisonCharts/ComparisonChartsWrapper.tsx
+++ b/components/ComparisonCharts/ComparisonChartsWrapper.tsx
@@ -10,6 +10,7 @@ import { useComparisonChartTime } from "@/hooks/useComparisonChartTime";
 
 import ComparisonChartsTimeSelector from "./ComparisonChartsTimeSelector";
 import PriceComparisonChartWrapper from "./PriceComparisonChartWrapper";
+import VolumeChartSwitcher from "./VolumeChartSwitcher";
 import VolumeComparisonChartWrapper from "./VolumeComparisonChartWrapper";
 
 const ComparisonChartsWrapper = () => {
@@ -45,8 +46,9 @@ const ComparisonChartsWrapper = () => {
           <VolumeComparisonChartWrapper chartData={chartData} />
         </div>
       </div>
-      <div className="mt-[14px]">
+      <div className="flex justify-between mt-[10px] mb-4">
         <ComparisonChartsTimeSelector isPending={pulseChartBackground} />
+        <VolumeChartSwitcher isPending={pulseChartBackground} />
       </div>
     </div>
   );

--- a/components/ComparisonCharts/VolumeChartSwitcher.tsx
+++ b/components/ComparisonCharts/VolumeChartSwitcher.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/utils/cn";
+import {
+  useVolumeChartActions,
+  useVolumeChartModeIsSelected as isSelected,
+} from "@/hooks/useVolumeChartMode";
+
+type Props = {
+  isPending: boolean;
+};
+
+const VolumeChartSwitcher = ({ isPending }: Props) => {
+  const { changeMode } = useVolumeChartActions();
+
+  return (
+    <div className="rounded-2xl inline-flex p-1 bg-zinc-900/70 border border-zinc-800 gap-x-1 font-light">
+      <button
+        className={cn(
+          "min-w-[80px] px-3 py-2 rounded-xl hover:bg-teal-900/80 text-stone-300 transition-colors disabled:cursor-not-allowed",
+          isSelected("overlap") && "hover:bg-teal-800 bg-teal-900/80",
+          isPending && "text-muted animate-pulse"
+        )}
+        onClick={() => changeMode("overlap")}
+        disabled={isPending}
+      >
+        overlap
+      </button>
+      <button
+        className={cn(
+          "min-w-[80px] px-3 py-2 rounded-xl hover:bg-teal-900/80 text-stone-300 transition-colors disabled:cursor-not-allowed",
+          isSelected("stack") && "hover:bg-teal-800 bg-teal-900/80",
+          isPending && "text-muted animate-pulse"
+        )}
+        onClick={() => changeMode("stack")}
+        disabled={isPending}
+      >
+        stack
+      </button>
+    </div>
+  );
+};
+
+export default VolumeChartSwitcher;

--- a/components/ComparisonCharts/VolumeComparisonChart.tsx
+++ b/components/ComparisonCharts/VolumeComparisonChart.tsx
@@ -1,8 +1,13 @@
-import type { ChartData } from "chart.js";
+import type { ChartData, ScriptableContext } from "chart.js";
 import type { ComparisonChartResponse } from "@/utils/types";
 
 import { chartColorSets } from "@/utils/comparisonChartHelpers/compareGeneralHelpers";
 import { prepareComparisonData } from "@/utils/comparisonChartHelpers/prepareComparisonData";
+import {
+  stackOne,
+  stackThree,
+  stackTwo,
+} from "@/utils/comparisonChartHelpers/compareVolumeHelpers";
 import { useCarouselSelectedElements } from "@/hooks/useCarousel";
 import { volumeComparisonOptions } from "@/utils/comparisonChartHelpers/compareVolumeHelpers";
 import { volumeComparisonGradient } from "@/utils/comparisonChartHelpers/compareVolumeHelpers";
@@ -16,17 +21,63 @@ type Props = {
 const VolumeComparisonChart = ({ chartData }: Props) => {
   const selectedCoins = useCarouselSelectedElements();
   const { label, values } = prepareComparisonData(chartData, "total_volumes");
+  const stacked = () => {
+    switch (chartData.length) {
+      default:
+      case 1:
+        return stackOne(values, selectedCoins);
+      case 2:
+        return stackTwo(values, selectedCoins);
+      case 3:
+        return stackThree(values, selectedCoins);
+    }
+  };
+
+  const bg = (idx: number, context: ScriptableContext<"bar">) => {
+    return stacked().map((ele) => {
+      if (ele[idx].name === selectedCoins[0]) {
+        return volumeComparisonGradient(context, 0);
+      } else if (ele[idx].name === selectedCoins[1]) {
+        return volumeComparisonGradient(context, 1);
+      } else {
+        return volumeComparisonGradient(context, 2);
+      }
+    });
+  };
+
+  const bgHover = (idx: number) => {
+    return stacked().map((ele) => {
+      if (ele[idx].name === selectedCoins[0]) {
+        return chartColorSets[0].highlightColor.hex;
+      } else if (ele[idx].name === selectedCoins[1]) {
+        return chartColorSets[1].highlightColor.hex;
+      } else {
+        return chartColorSets[2].highlightColor.hex;
+      }
+    });
+  };
 
   const volumeChartData: ChartData<"bar"> = {
     labels: label,
+
+    /**
+     * The compiler will throw an error here even though the charts work without any issues.
+     * The backgroundColor prop accepts an array; but if that array is generated through the callback it's not considered valid for some reason.
+     *
+     * I have raised a github issue about this:
+     * https://github.com/chartjs/Chart.js/issues/11711
+     *
+     * ts-ignore for now
+     */
+    // @ts-ignore
     datasets: chartData.map((_, idx) => {
       return {
         backgroundColor: function (context) {
-          return volumeComparisonGradient(context, idx);
+          return bg(idx, context);
         },
-        data: values[idx],
-        label: selectedCoins[idx],
-        hoverBackgroundColor: chartColorSets[idx].highlightColor.hex,
+        data: stacked().map((ele) => ele[idx].volume),
+        label: idx.toString(),
+        hoverBackgroundColor: bgHover(idx),
       };
     }),
   };

--- a/components/ComparisonCharts/VolumeComparisonChart.tsx
+++ b/components/ComparisonCharts/VolumeComparisonChart.tsx
@@ -21,7 +21,7 @@ type Props = {
 const VolumeComparisonChart = ({ chartData }: Props) => {
   const selectedCoins = useCarouselSelectedElements();
   const { label, values } = prepareComparisonData(chartData, "total_volumes");
-  const stacked = () => {
+  const stacked = (() => {
     switch (chartData.length) {
       default:
       case 1:
@@ -31,10 +31,10 @@ const VolumeComparisonChart = ({ chartData }: Props) => {
       case 3:
         return stackThree(values, selectedCoins);
     }
-  };
+  })();
 
   const bg = (idx: number, context: ScriptableContext<"bar">) => {
-    return stacked().map((ele) => {
+    return stacked.map((ele) => {
       if (ele[idx].name === selectedCoins[0]) {
         return volumeComparisonGradient(context, 0);
       } else if (ele[idx].name === selectedCoins[1]) {
@@ -46,7 +46,7 @@ const VolumeComparisonChart = ({ chartData }: Props) => {
   };
 
   const bgHover = (idx: number) => {
-    return stacked().map((ele) => {
+    return stacked.map((ele) => {
       if (ele[idx].name === selectedCoins[0]) {
         return chartColorSets[0].highlightColor.hex;
       } else if (ele[idx].name === selectedCoins[1]) {
@@ -75,7 +75,7 @@ const VolumeComparisonChart = ({ chartData }: Props) => {
         backgroundColor: function (context) {
           return bg(idx, context);
         },
-        data: stacked().map((ele) => ele[idx].volume),
+        data: stacked.map((ele) => ele[idx].volume),
         label: idx.toString(),
         hoverBackgroundColor: bgHover(idx),
       };

--- a/components/ComparisonCharts/VolumeComparisonChart.tsx
+++ b/components/ComparisonCharts/VolumeComparisonChart.tsx
@@ -3,10 +3,10 @@ import type { ComparisonChartResponse } from "@/utils/types";
 
 import { prepareComparisonData } from "@/utils/comparisonChartHelpers/prepareComparisonData";
 import {
-  getStackedBackgroundColor,
-  getStackedHoverColor,
-  getVolumeChartOptions,
-  stackDataRelative,
+  getOptionsOverlapped,
+  getOverlapBackgroundColor,
+  getOverlapHoverColor,
+  overlapData,
 } from "@/utils/comparisonChartHelpers/compareVolumeHelpers";
 import { useCarouselSelectedElements } from "@/hooks/useCarousel";
 
@@ -18,11 +18,11 @@ type Props = {
 
 const VolumeComparisonChart = ({ chartData }: Props) => {
   const coinLabels = useCarouselSelectedElements();
-  const { label, values } = prepareComparisonData(chartData, "total_volumes");
-  const stackedValues = stackDataRelative(values, coinLabels);
+  const { label: x, values } = prepareComparisonData(chartData, "total_volumes");
+  const overlapValues = overlapData(values, coinLabels);
 
   const volumeChartData: ChartData<"bar"> = {
-    labels: label,
+    labels: x,
 
     /**
      * The compiler will throw an error here even though the charts work without any issues.
@@ -37,27 +37,30 @@ const VolumeComparisonChart = ({ chartData }: Props) => {
     datasets: chartData.map((_, idx) => {
       return {
         backgroundColor: function (context) {
-          return getStackedBackgroundColor(
+          return getOverlapBackgroundColor(
             idx,
             context,
-            stackedValues,
+            overlapValues,
             coinLabels
           );
         },
-        hoverBackgroundColor: getStackedHoverColor(
+        hoverBackgroundColor: getOverlapHoverColor(
           idx,
-          stackedValues,
+          overlapValues,
           coinLabels
         ),
 
-        data: stackedValues.map((ele) => ele[idx].volume),
+        data: overlapValues.map((ele) => ele[idx].volume),
         label: idx.toString(),
       };
     }),
   };
 
   return (
-    <Bar data={volumeChartData} options={getVolumeChartOptions(coinLabels)} />
+    <Bar
+      data={volumeChartData}
+      options={getOptionsOverlapped(overlapValues, x, coinLabels)}
+    />
   );
 };
 

--- a/components/ComparisonCharts/VolumeComparisonChart.tsx
+++ b/components/ComparisonCharts/VolumeComparisonChart.tsx
@@ -4,12 +4,10 @@ import type { ComparisonChartResponse } from "@/utils/types";
 import { chartColorSets } from "@/utils/comparisonChartHelpers/compareGeneralHelpers";
 import { prepareComparisonData } from "@/utils/comparisonChartHelpers/prepareComparisonData";
 import {
-  stackOne,
-  stackThree,
-  stackTwo,
+  getVolumeChartOptions,
+  stackItUp,
 } from "@/utils/comparisonChartHelpers/compareVolumeHelpers";
 import { useCarouselSelectedElements } from "@/hooks/useCarousel";
-import { volumeComparisonOptions } from "@/utils/comparisonChartHelpers/compareVolumeHelpers";
 import { volumeComparisonGradient } from "@/utils/comparisonChartHelpers/compareVolumeHelpers";
 
 import { Bar } from "react-chartjs-2";
@@ -21,20 +19,10 @@ type Props = {
 const VolumeComparisonChart = ({ chartData }: Props) => {
   const selectedCoins = useCarouselSelectedElements();
   const { label, values } = prepareComparisonData(chartData, "total_volumes");
-  const stacked = (() => {
-    switch (chartData.length) {
-      default:
-      case 1:
-        return stackOne(values, selectedCoins);
-      case 2:
-        return stackTwo(values, selectedCoins);
-      case 3:
-        return stackThree(values, selectedCoins);
-    }
-  })();
+  const stackedValues = stackItUp(values, selectedCoins);
 
   const bg = (idx: number, context: ScriptableContext<"bar">) => {
-    return stacked.map((ele) => {
+    return stackedValues.map((ele) => {
       if (ele[idx].name === selectedCoins[0]) {
         return volumeComparisonGradient(context, 0);
       } else if (ele[idx].name === selectedCoins[1]) {
@@ -46,7 +34,7 @@ const VolumeComparisonChart = ({ chartData }: Props) => {
   };
 
   const bgHover = (idx: number) => {
-    return stacked.map((ele) => {
+    return stackedValues.map((ele) => {
       if (ele[idx].name === selectedCoins[0]) {
         return chartColorSets[0].highlightColor.hex;
       } else if (ele[idx].name === selectedCoins[1]) {
@@ -75,14 +63,19 @@ const VolumeComparisonChart = ({ chartData }: Props) => {
         backgroundColor: function (context) {
           return bg(idx, context);
         },
-        data: stacked.map((ele) => ele[idx].volume),
+        data: stackedValues.map((ele) => ele[idx].volume),
         label: idx.toString(),
         hoverBackgroundColor: bgHover(idx),
       };
     }),
   };
 
-  return <Bar data={volumeChartData} options={volumeComparisonOptions} />;
+  return (
+    <Bar
+      data={volumeChartData}
+      options={getVolumeChartOptions(selectedCoins)}
+    />
+  );
 };
 
 export default VolumeComparisonChart;

--- a/components/ComparisonCharts/VolumeComparisonChartWrapper.tsx
+++ b/components/ComparisonCharts/VolumeComparisonChartWrapper.tsx
@@ -3,9 +3,11 @@
 import type { ComparisonChartResponse } from "@/utils/types";
 
 import { useCarouselHasNoneSelected } from "@/hooks/useCarousel";
+import { useVolumeChartMode } from "@/hooks/useVolumeChartMode";
 
 import { ErrorBoundary } from "react-error-boundary";
-import VolumeComparisonChart from "./VolumeComparisonChart";
+import VolumeOverlapComparisonChart from "./VolumeOverlapComparisonChart";
+import VolumeStackComparisonChart from "./VolumeStackComparisonChart";
 
 type Props = {
   chartData: ComparisonChartResponse[];
@@ -14,11 +16,15 @@ type Props = {
 const PriceComparisonChartWrapper = ({ chartData }: Props) => {
   const hasNoneSelected = useCarouselHasNoneSelected();
   const hasNoData = chartData.length === 0;
+  const mode = useVolumeChartMode();
 
-  if (hasNoneSelected || hasNoData)
+  if (hasNoneSelected || hasNoData) {
     return (
-      <p className="mt-4 font-light text-center text-stone-400/50">No data to display.</p>
+      <p className="mt-4 font-light text-center text-stone-400/50">
+        No data to display.
+      </p>
     );
+  }
 
   return (
     <div className="w-full h-full p-4">
@@ -29,7 +35,11 @@ const PriceComparisonChartWrapper = ({ chartData }: Props) => {
           </p>
         }
       >
-        <VolumeComparisonChart chartData={chartData} />
+        {mode === "stack" ? (
+          <VolumeStackComparisonChart chartData={chartData} />
+        ) : (
+          <VolumeOverlapComparisonChart chartData={chartData} />
+        )}
       </ErrorBoundary>
     </div>
   );

--- a/components/ComparisonCharts/VolumeOverlapComparisonChart.tsx
+++ b/components/ComparisonCharts/VolumeOverlapComparisonChart.tsx
@@ -50,7 +50,7 @@ const VolumeOverlapComparisonChart = ({ chartData }: Props) => {
           coinLabels
         ),
 
-        data: overlapValues.map((ele) => ele[idx].volume),
+        data: overlapValues.map((value) => value[idx].volume),
         label: idx.toString(),
       };
     }),

--- a/components/ComparisonCharts/VolumeOverlapComparisonChart.tsx
+++ b/components/ComparisonCharts/VolumeOverlapComparisonChart.tsx
@@ -18,22 +18,14 @@ type Props = {
 
 const VolumeOverlapComparisonChart = ({ chartData }: Props) => {
   const coinLabels = useCarouselSelectedElements();
-  const { label: x, values } = prepareComparisonData(chartData, "total_volumes");
+  const { label: x, values } = prepareComparisonData(
+    chartData,
+    "total_volumes"
+  );
   const overlapValues = overlapData(values, coinLabels);
 
   const volumeChartData: ChartData<"bar"> = {
     labels: x,
-
-    /**
-     * The compiler will throw an error here even though the charts work without any issues.
-     * The backgroundColor prop accepts an array; but if that array is generated through the callback it's not considered valid for some reason.
-     *
-     * I have raised a github issue about this:
-     * https://github.com/chartjs/Chart.js/issues/11711
-     *
-     * ts-ignore for now
-     */
-    // @ts-ignore
     datasets: chartData.map((_, idx) => {
       return {
         backgroundColor: function (context) {
@@ -44,11 +36,9 @@ const VolumeOverlapComparisonChart = ({ chartData }: Props) => {
             coinLabels
           );
         },
-        hoverBackgroundColor: getOverlapHoverColor(
-          idx,
-          overlapValues,
-          coinLabels
-        ),
+        hoverBackgroundColor: function (context) {
+          return getOverlapHoverColor(idx, context, overlapValues, coinLabels);
+        },
 
         data: overlapValues.map((value) => value[idx].volume),
         label: idx.toString(),

--- a/components/ComparisonCharts/VolumeOverlapComparisonChart.tsx
+++ b/components/ComparisonCharts/VolumeOverlapComparisonChart.tsx
@@ -16,7 +16,7 @@ type Props = {
   chartData: ComparisonChartResponse[];
 };
 
-const VolumeComparisonChart = ({ chartData }: Props) => {
+const VolumeOverlapComparisonChart = ({ chartData }: Props) => {
   const coinLabels = useCarouselSelectedElements();
   const { label: x, values } = prepareComparisonData(chartData, "total_volumes");
   const overlapValues = overlapData(values, coinLabels);
@@ -64,4 +64,4 @@ const VolumeComparisonChart = ({ chartData }: Props) => {
   );
 };
 
-export default VolumeComparisonChart;
+export default VolumeOverlapComparisonChart;

--- a/components/ComparisonCharts/VolumeStackComparisonChart.tsx
+++ b/components/ComparisonCharts/VolumeStackComparisonChart.tsx
@@ -1,0 +1,40 @@
+import type { ChartData } from "chart.js";
+import type { ComparisonChartResponse } from "@/utils/types";
+
+import { chartColorSets } from "@/utils/comparisonChartHelpers/compareGeneralHelpers";
+import {
+  chartOptionsStacked,
+  volumeComparisonGradient,
+} from "@/utils/comparisonChartHelpers/compareVolumeHelpers";
+import { prepareComparisonData } from "@/utils/comparisonChartHelpers/prepareComparisonData";
+import { useCarouselSelectedElements } from "@/hooks/useCarousel";
+
+import { Bar } from "react-chartjs-2";
+
+type Props = {
+  chartData: ComparisonChartResponse[];
+};
+
+const VolumeStackComparisonChart = ({ chartData }: Props) => {
+  const coinLabels = useCarouselSelectedElements();
+  const { label, values } = prepareComparisonData(chartData, "total_volumes");
+
+  const volumeChartData: ChartData<"bar"> = {
+    labels: label,
+
+    datasets: chartData.map((_, idx) => {
+      return {
+        backgroundColor: function (context) {
+          return volumeComparisonGradient(context, idx);
+        },
+        hoverBackgroundColor: chartColorSets[idx].highlightColor.hex,
+        data: values[idx],
+        label: coinLabels[idx],
+      };
+    }),
+  };
+
+  return <Bar data={volumeChartData} options={chartOptionsStacked} />;
+};
+
+export default VolumeStackComparisonChart;

--- a/hooks/useVolumeChartMode.ts
+++ b/hooks/useVolumeChartMode.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+
+type VolumeChartModeState = {
+  mode: "stack" | "overlap";
+  actions: VolumeChartModeAction;
+};
+
+type VolumeChartModeAction = {
+  changeMode: (mode: VolumeChartModeState["mode"]) => void;
+};
+
+const useVolumeChartModeStore = create<VolumeChartModeState>((set) => ({
+  mode: "overlap",
+  actions: {
+    changeMode: (mode) => set(() => ({ mode: mode })),
+  },
+}));
+
+export const useVolumeChartMode = () => {
+  return useVolumeChartModeStore((state) => state.mode);
+};
+export const useVolumeChartModeIsSelected = (
+  mode: VolumeChartModeState["mode"]
+) => {
+  return useVolumeChartModeStore((state) => state.mode === mode);
+};
+export const useVolumeChartActions = () => {
+  return useVolumeChartModeStore((state) => state.actions);
+};

--- a/utils/comparisonChartHelpers/compareGeneralHelpers.ts
+++ b/utils/comparisonChartHelpers/compareGeneralHelpers.ts
@@ -36,8 +36,9 @@ import { formatPriceChangeValue } from "../formatHelpers";
 export const decimationThreshold = 150;
 
 export const gridColor = "#27272A";
+export const legendFontColor = "#A1A1AA";
 export const tooltipBackgroundColor = "#121212";
-export const tooltipBorderColor = "#D4D4D8";
+export const tooltipBorderColor = "#71717A";
 
 export function handleGradientColorStops(
   alphaValues: { alphaStart: number; alphaEnd: number },

--- a/utils/comparisonChartHelpers/comparePriceHelpers.ts
+++ b/utils/comparisonChartHelpers/comparePriceHelpers.ts
@@ -64,7 +64,8 @@ export const priceComparisonOptions: ChartOptions<"line"> = {
       borderColor: tooltipBorderColor,
       borderWidth: 1,
       caretPadding: 14,
-      yAlign: "top",
+      position: "nearest",
+      yAlign: "bottom",
     },
   },
   interaction: {

--- a/utils/comparisonChartHelpers/compareVolumeHelpers.ts
+++ b/utils/comparisonChartHelpers/compareVolumeHelpers.ts
@@ -304,24 +304,10 @@ export function overlapData(datasets: number[][], labels: string[]) {
 }
 
 /**
- * Returns the index that the name of the point corresponds to in the
- * selected carousel elements. This determines what color the point should use.
- */
-function getPointNameIdx(
-  points: OverlappedVolumeData[],
-  idx: number,
-  labels: string[]
-) {
-  return labels.findIndex((label) => label === points[idx].name);
-}
-
-/**
  * Generates an array of backgroundColor values each dataset should use.
  *
  * Because the data is being overlapped, the same dataset needs to have different
  * background colors depending on what the smallest value is for all the datasets.
- *
- * If a larger value is drawn over it; it will be overridden and unable to be seen.
  */
 export function getOverlapBackgroundColor(
   idx: number,
@@ -329,10 +315,9 @@ export function getOverlapBackgroundColor(
   overlapValues: OverlappedVolumeData[][],
   labels: string[]
 ) {
-  return overlapValues.map((points) => {
-    const nameIdx = getPointNameIdx(points, idx, labels);
-    return volumeComparisonGradient(context, nameIdx);
-  });
+  const name = overlapValues[context.dataIndex][idx].name;
+  const nameIdx = labels.findIndex((label) => label === name);
+  return volumeComparisonGradient(context, nameIdx);
 }
 
 /**
@@ -340,11 +325,11 @@ export function getOverlapBackgroundColor(
  */
 export function getOverlapHoverColor(
   idx: number,
+  context: ScriptableContext<"bar">,
   overlapValues: OverlappedVolumeData[][],
   labels: string[]
 ) {
-  return overlapValues.map((points) => {
-    const nameIdx = getPointNameIdx(points, idx, labels);
-    return chartColorSets[nameIdx].highlightColor.hex;
-  });
+  const name = overlapValues[context.dataIndex][idx].name;
+  const nameIdx = labels.findIndex((label) => label === name);
+  return chartColorSets[nameIdx].highlightColor.hex;
 }

--- a/utils/comparisonChartHelpers/compareVolumeHelpers.ts
+++ b/utils/comparisonChartHelpers/compareVolumeHelpers.ts
@@ -8,6 +8,7 @@ import {
   tooltipBackgroundColor,
   tooltipBorderColor,
 } from "./compareGeneralHelpers";
+import { sort } from "fast-sort";
 
 // https://www.chartjs.org/docs/latest/samples/advanced/linear-gradient.html
 export function volumeComparisonGradient(
@@ -95,3 +96,90 @@ export const volumeComparisonOptions: ChartOptions<"bar"> = {
     },
   },
 };
+
+type ComparisonData = { name: string; volume: number };
+
+export function stackOne(datasets: number[][], labels: string[]) {
+  let result: ComparisonData[][] = [];
+  for (let i = 0; i < datasets[0].length; i++) {
+    result.push([{ name: labels[0], volume: datasets[0][i] }]);
+  }
+
+  return result;
+}
+
+export function stackTwo(datasets: number[][], labels: string[]) {
+  let result: ComparisonData[][] = [];
+  for (let i = 0; i < datasets[0].length; i++) {
+    const dataPoint = [
+      {
+        name: labels[0],
+        volume: datasets[0][i],
+      },
+      {
+        name: labels[1],
+        volume: datasets[1][i],
+      },
+    ];
+    const sortedPoint = sort(dataPoint).by([{ asc: (label) => label.volume }]);
+
+    const correctedPoint: ComparisonData[] = [
+      {
+        name: sortedPoint[0].name,
+        volume: sortedPoint[0].volume,
+      },
+      {
+        name: sortedPoint[1].name,
+        volume: sortedPoint[1].volume - sortedPoint[0].volume,
+      },
+    ];
+
+    result.push(correctedPoint);
+  }
+
+  return result;
+}
+
+export function stackThree(datasets: number[][], labels: string[]) {
+  let result: ComparisonData[][] = [];
+  for (let i = 0; i < datasets[0].length; i++) {
+    const dataPoint = [
+      {
+        name: labels[0],
+        volume: datasets[0][i],
+      },
+      {
+        name: labels[1],
+        volume: datasets[1][i],
+      },
+      {
+        name: labels[2],
+        volume: datasets[2][i],
+      },
+    ];
+    const sortedPoint = sort(dataPoint).by([{ asc: (label) => label.volume }]);
+
+    const correctedPoint: ComparisonData[] = [
+      {
+        name: sortedPoint[0].name,
+        volume: sortedPoint[0].volume,
+      },
+      {
+        name: sortedPoint[1].name,
+        volume: sortedPoint[1].volume - sortedPoint[0].volume,
+      },
+      {
+        name: sortedPoint[2].name,
+        volume: sortedPoint[2].volume - sortedPoint[1].volume,
+      },
+    ];
+
+    result.push(correctedPoint);
+  }
+
+  return result;
+}
+
+export function stackData(datasets: number[][], lables: string[]) {
+  
+}

--- a/utils/comparisonChartHelpers/compareVolumeHelpers.ts
+++ b/utils/comparisonChartHelpers/compareVolumeHelpers.ts
@@ -315,8 +315,8 @@ export function getOverlapBackgroundColor(
   overlapValues: OverlappedVolumeData[][],
   labels: string[]
 ) {
-  const name = overlapValues[context.dataIndex][idx].name;
-  const nameIdx = labels.findIndex((label) => label === name);
+  const coinName = overlapValues[context.dataIndex][idx].name;
+  const nameIdx = labels.findIndex((label) => label === coinName);
   return volumeComparisonGradient(context, nameIdx);
 }
 
@@ -329,7 +329,7 @@ export function getOverlapHoverColor(
   overlapValues: OverlappedVolumeData[][],
   labels: string[]
 ) {
-  const name = overlapValues[context.dataIndex][idx].name;
-  const nameIdx = labels.findIndex((label) => label === name);
+  const coinName = overlapValues[context.dataIndex][idx].name;
+  const nameIdx = labels.findIndex((label) => label === coinName);
   return chartColorSets[nameIdx].highlightColor.hex;
 }

--- a/utils/comparisonChartHelpers/compareVolumeHelpers.ts
+++ b/utils/comparisonChartHelpers/compareVolumeHelpers.ts
@@ -1,4 +1,4 @@
-import type { ChartOptions, LegendItem, ScriptableContext } from "chart.js";
+import type { ChartOptions, ScriptableContext } from "chart.js";
 import type { OverlappedVolumeData } from "../types";
 
 import { arrayOfNs } from "../arrayHelpers";
@@ -48,7 +48,7 @@ export function volumeComparisonGradient(
   return gradient;
 }
 
-export const volumeComparisonOptions: ChartOptions<"bar"> = {
+export const chartOptionsStacked: ChartOptions<"bar"> = {
   plugins: {
     legend: {
       position: "top",

--- a/utils/comparisonChartHelpers/compareVolumeHelpers.ts
+++ b/utils/comparisonChartHelpers/compareVolumeHelpers.ts
@@ -255,7 +255,7 @@ export function stackThree(datasets: number[][], labels: string[]) {
   return result;
 }
 
-export function stackItUp(datasets: number[][], labels: string[]) {
+export function stackDataRelative(datasets: number[][], labels: string[]) {
   let result: StackedData[][] = [];
 
   // this will only work if all datasets are the same length
@@ -298,4 +298,29 @@ export function stackItUp(datasets: number[][], labels: string[]) {
   }
 
   return result;
+}
+
+export function getStackedBackgroundColor(
+  idx: number,
+  context: ScriptableContext<"bar">,
+  stackedValues: StackedData[][],
+  labels: string[],
+) {
+  return stackedValues.map((value) => {
+    const name = value[idx].name;
+    const nameIdx = labels.findIndex((label) => label === name);
+    return volumeComparisonGradient(context, nameIdx);
+  });
+}
+
+export function getStackedHoverColor(
+  idx: number,
+  stackedValues: StackedData[][],
+  labels: string[]
+) {
+  return stackedValues.map((value) => {
+    const name = value[idx].name;
+    const nameIdx = labels.findIndex((label) => label === name);
+    return chartColorSets[nameIdx].highlightColor.hex;
+  });
 }

--- a/utils/comparisonChartHelpers/compareVolumeHelpers.ts
+++ b/utils/comparisonChartHelpers/compareVolumeHelpers.ts
@@ -116,12 +116,14 @@ export function getOptionsOverlapped(
         position: "top",
         align: "end",
         labels: {
-          // need to customize legend labels because same datasets will have different colors
+          // Need to customize legend labels because the same dataset is going to have different colors if it's relative magnitude
+          // to the other datasets changes.
+          // So, the coloring has to be done via the corresponding name of the point in the dataset instead of the dataset itself.
           // https://www.chartjs.org/docs/latest/configuration/legend.html#legend-item-interface
           generateLabels: () =>
-            carouselSelected.map((ele, idx) => {
+            carouselSelected.map((coinName, idx) => {
               return {
-                text: ele,
+                text: coinName,
                 fontColor: legendFontColor,
                 fillStyle: chartColorSets[idx].startColor.hex,
                 hidden: false,

--- a/utils/formatHelpers.ts
+++ b/utils/formatHelpers.ts
@@ -25,12 +25,12 @@ export function formatPriceChangePercentage(price: number) {
  * 100_000 -> 100k
  * 2_000_000 -> 2M
  */
-export function formatPriceChangeValue(price: number) {
+export function formatPriceChangeValue(price: number, numTrailing: number = 2) {
   return price < 0.01
     ? formatSmallNum(price)
     : Intl.NumberFormat("en-US", {
         notation: "compact",
-        maximumFractionDigits: 2,
+        maximumFractionDigits: numTrailing,
       }).format(price);
 }
 

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -76,3 +76,8 @@ export type MarketQueryResult = UseInfiniteQueryResult<
   InfiniteData<MarketResponse, unknown>,
   Error
 >;
+
+export type OverlappedVolumeData = {
+  name: string;
+  volume: number;
+}


### PR DESCRIPTION
Creates an overlapping (as opposed to stacked) bar chart and allows users to switch between formats.

- Overlapping chart: Scale is preserved, users clearly see when data series becomes smaller or larger than others. Datasets appear to "weave" around each other. The value of a colored bar is equal to the magnitude of that bar plus any bars below it.
- Stacked chart: Scale is not preserved, the size of each colored bar is equal to the magnitude of the value in the dataset.

https://github.com/agreen254/crypto-app/assets/101513222/9940a1d3-54fb-4fd2-b6a8-96886fdf6621

