### PR TITLE
Add editing/deleting for assets

### DIFF
--- a/components/Portfolio/AssetDisplay/AssetDisplay.tsx
+++ b/components/Portfolio/AssetDisplay/AssetDisplay.tsx
@@ -9,7 +9,7 @@ import ProgressWidget from "@/components/ProgressWidget";
 import { assetDisplayData } from "@/utils/assetDisplayData";
 import { cn } from "@/utils/cn";
 import { currencyMap } from "@/utils/maps";
-import { extractDate } from "@/utils/extractDate";
+import { extractDate } from "@/utils/dateHelpers";
 import { localeFormat } from "@/utils/formatHelpers";
 import { useUserCurrencySetting } from "@/hooks/useUserSettings";
 

--- a/components/Portfolio/AssetDisplay/AssetDisplay.tsx
+++ b/components/Portfolio/AssetDisplay/AssetDisplay.tsx
@@ -1,12 +1,11 @@
 import type { Asset, AssetCurrent, AssetHistory } from "@/utils/types";
 
+import AssetModalWrapper from "../AssetModal/AssetModalWrapper";
 import CaretIcon from "@/Icons/Caret";
 import Image from "next/image";
 import { Infinity as InfinityIcon } from "lucide-react";
 import ProgressWidget from "@/components/ProgressWidget";
-import { SquarePen as SquarePenIcon } from "lucide-react";
 
-import { useId } from "react";
 import { assetDisplayData } from "@/utils/assetDisplayData";
 import { cn } from "@/utils/cn";
 import { currencyMap } from "@/utils/maps";
@@ -24,7 +23,6 @@ const AssetDisplay = ({ asset, assetCurrent, assetHistory }: Props) => {
   const { coinName, coinSymbol, coinImage, date } = asset;
   const currency = useUserCurrencySetting();
 
-  const editButtonId = useId();
   const displayDate = extractDate(date).toLocaleString("en-US", {
     dateStyle: "medium",
   });
@@ -170,12 +168,7 @@ const AssetDisplay = ({ asset, assetCurrent, assetHistory }: Props) => {
         />
       </div>
       <div className="relative min-w-[380px] w-[380px] flex flex-col justify-start pb-6 pt-4 gap-y-3 bg-teal-950/70">
-        <label htmlFor={editButtonId} className="sr-only">
-          edit this asset
-        </label>
-        <button id={editButtonId} className="absolute top-3 right-4">
-          <SquarePenIcon className="w-6 h-6" />
-        </button>
+        <AssetModalWrapper role="edit" initialData={asset} />
         <div className="flex items-center">
           <span
             className={cn("text-3xl", !maybeDisplayData && "animate-pulse")}

--- a/components/Portfolio/AssetDisplay/AssetDisplay.tsx
+++ b/components/Portfolio/AssetDisplay/AssetDisplay.tsx
@@ -5,13 +5,15 @@ import CaretIcon from "@/Icons/Caret";
 import Image from "next/image";
 import { Infinity as InfinityIcon } from "lucide-react";
 import ProgressWidget from "@/components/ProgressWidget";
+import { FileX2 as DeleteIcon } from "lucide-react";
 
+import { useDeleteAsset } from "@/hooks/useAssets";
+import { useUserCurrencySetting } from "@/hooks/useUserSettings";
 import { assetDisplayData } from "@/utils/assetDisplayData";
 import { cn } from "@/utils/cn";
 import { currencyMap } from "@/utils/maps";
 import { extractDate } from "@/utils/dateHelpers";
 import { localeFormat } from "@/utils/formatHelpers";
-import { useUserCurrencySetting } from "@/hooks/useUserSettings";
 
 type Props = {
   asset: Asset;
@@ -22,6 +24,7 @@ type Props = {
 const AssetDisplay = ({ asset, assetCurrent, assetHistory }: Props) => {
   const { coinName, coinSymbol, coinImage, date } = asset;
   const currency = useUserCurrencySetting();
+  const deleteAsset = useDeleteAsset(asset.assetId, asset.date);
 
   const displayDate = extractDate(date).toLocaleString("en-US", {
     dateStyle: "medium",
@@ -169,6 +172,12 @@ const AssetDisplay = ({ asset, assetCurrent, assetHistory }: Props) => {
       </div>
       <div className="relative min-w-[380px] w-[380px] flex flex-col justify-start pb-6 pt-4 gap-y-3 bg-teal-950/70">
         <AssetModalWrapper role="edit" initialData={asset} />
+        <button
+          className="absolute top-12 right-4 p-1 rounded-md border-2 border-white/0 focus:outline-none focus:border-stone-500"
+          onClick={deleteAsset}
+        >
+          <DeleteIcon className="w-6 h-6" />
+        </button>
         <div className="flex items-center">
           <span
             className={cn("text-3xl", !maybeDisplayData && "animate-pulse")}

--- a/components/Portfolio/AssetModal/AssetModalAddActivator.tsx
+++ b/components/Portfolio/AssetModal/AssetModalAddActivator.tsx
@@ -14,7 +14,7 @@ const AssetModalAddActivator = forwardRef(
     return (
       <button
         ref={ref}
-        className="px-5 py-[10px] w-[256px] font-medium bg-teal-700 shadow-[0_0_20px_8px] shadow-market-teal/15 border border-white/0 rounded-md focus:outline-none focus:border-stone-300"
+        className="px-5 py-[10px] w-[256px] font-medium bg-teal-700 shadow-[0_0_20px_8px] shadow-market-teal/15 box-content border border-white/0 rounded-md focus:outline-none focus:border-stone-300"
         onClick={() => setIsOpen((prev) => !prev)}
       >
         Add Asset

--- a/components/Portfolio/AssetModal/AssetModalBody.tsx
+++ b/components/Portfolio/AssetModal/AssetModalBody.tsx
@@ -293,7 +293,7 @@ const AssetModalBody = (
       };
       handleModalExit();
       forwardedActivatorRef.current?.focus();
-      updateAssets(asset);
+      updateAssets(asset, !!assetId);
     }
   };
 
@@ -305,7 +305,7 @@ const AssetModalBody = (
       ref={modalRef}
       className={cn(
         "h-full w-full hidden justify-center items-center fixed top-0 left-0 backdrop-blur-md z-10",
-        isOpen && "flex"
+        isOpen && "flex flex-col"
       )}
     >
       <div className="w-[886px] min-h-[400px] p-12 rounded-xl bg-zinc-900 border border-zinc-800">
@@ -369,7 +369,10 @@ const AssetModalBody = (
                 spellCheck="false"
                 disabled={!searchTargets || !!assetId}
                 searchResults={searchResults}
-                className={cn("h-11 w-full p-2 rounded-lg bg-zinc-800/60", !!assetId && "text-muted-foreground")}
+                className={cn(
+                  "h-11 w-full p-2 rounded-lg bg-zinc-800/60",
+                  !!assetId && "text-muted-foreground"
+                )}
                 localQuery={coinQuery}
                 setLocalQuery={setCoinQuery}
                 onKeyDown={(e) => handleKeyDownSearch(e)}
@@ -542,7 +545,7 @@ const AssetModalBody = (
                   }
                 }}
               >
-                Add Asset
+                {assetId ? "Confirm Edit" : "Add Asset"}
               </button>
             </div>
           </div>

--- a/components/Portfolio/AssetModal/AssetModalEditActivator.tsx
+++ b/components/Portfolio/AssetModal/AssetModalEditActivator.tsx
@@ -28,7 +28,7 @@ const AssetModalEditActivator = (
   editButtonRef: ForwardedRef<HTMLButtonElement>
 ) => {
   const editButtonId = useId();
-  const injectData = useAssetModalInjectData(
+  const injectSelectedAssetData = useAssetModalInjectData(
     asset
       ? {
           assetId: asset.assetId,
@@ -51,7 +51,7 @@ const AssetModalEditActivator = (
         ref={editButtonRef}
         className="absolute top-3 right-4 p-1 rounded-md border-2 border-white/0 focus:outline-none focus:border-stone-500"
         onClick={() => {
-          if (!isOpen) injectData();
+          if (!isOpen) injectSelectedAssetData();
           setIsOpen((prev) => !prev);
         }}
       >

--- a/components/Portfolio/AssetModal/AssetModalEditActivator.tsx
+++ b/components/Portfolio/AssetModal/AssetModalEditActivator.tsx
@@ -1,5 +1,37 @@
-const AssetModalEditActivator = () => {
-  return <div>To-do</div>;
+import {
+  forwardRef,
+  useId,
+  type ForwardedRef,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+
+import { SquarePen as SquarePenIcon } from "lucide-react";
+
+type Props = {
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
 };
 
-export default AssetModalEditActivator;
+const AssetModalEditActivator = (
+  { setIsOpen }: Props,
+  editButtonRef: ForwardedRef<HTMLButtonElement>
+) => {
+  const editButtonId = useId();
+  return (
+    <>
+      <label htmlFor={editButtonId} className="sr-only">
+        edit this asset
+      </label>
+      <button
+        id={editButtonId}
+        ref={editButtonRef}
+        className="absolute top-3 right-4 p-1 rounded-md border-2 border-white/0 focus:outline-none focus:border-stone-500"
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        <SquarePenIcon className="w-6 h-6" />
+      </button>
+    </>
+  );
+};
+
+export default forwardRef(AssetModalEditActivator);

--- a/components/Portfolio/AssetModal/AssetModalEditActivator.tsx
+++ b/components/Portfolio/AssetModal/AssetModalEditActivator.tsx
@@ -1,3 +1,9 @@
+"use client";
+
+import type { Asset } from "@/utils/types";
+
+import { SquarePen as SquarePenIcon } from "lucide-react";
+
 import {
   forwardRef,
   useId,
@@ -5,18 +11,36 @@ import {
   type Dispatch,
   type SetStateAction,
 } from "react";
-
-import { SquarePen as SquarePenIcon } from "lucide-react";
+import {
+  defaultAssetModalProps,
+  useAssetModalInjectData,
+} from "@/hooks/useAssetModal";
+import { swapDateApiToInput } from "@/utils/dateHelpers";
 
 type Props = {
+  asset: Asset | undefined;
+  isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
 };
 
 const AssetModalEditActivator = (
-  { setIsOpen }: Props,
+  { asset, isOpen, setIsOpen }: Props,
   editButtonRef: ForwardedRef<HTMLButtonElement>
 ) => {
   const editButtonId = useId();
+  const injectData = useAssetModalInjectData(
+    asset
+      ? {
+          assetId: asset.assetId,
+          coinId: asset.coinId,
+          coinQuery: asset.coinName,
+          date: swapDateApiToInput(asset.date),
+          value: asset.value.toString(),
+          valueCurrency: asset.valueCurrency,
+        }
+      : defaultAssetModalProps
+  );
+
   return (
     <>
       <label htmlFor={editButtonId} className="sr-only">
@@ -26,7 +50,10 @@ const AssetModalEditActivator = (
         id={editButtonId}
         ref={editButtonRef}
         className="absolute top-3 right-4 p-1 rounded-md border-2 border-white/0 focus:outline-none focus:border-stone-500"
-        onClick={() => setIsOpen((prev) => !prev)}
+        onClick={() => {
+          if (!isOpen) injectData();
+          setIsOpen((prev) => !prev);
+        }}
       >
         <SquarePenIcon className="w-6 h-6" />
       </button>

--- a/components/Portfolio/AssetModal/AssetModalWrapper.tsx
+++ b/components/Portfolio/AssetModal/AssetModalWrapper.tsx
@@ -36,12 +36,16 @@ const AssetModalWrapper = ({ role, initialData }: Props) => {
     </DropdownProvider>
   ) : (
     <DropdownProvider initialUnits={dropdownUnits}>
-      <AssetModalEditActivator ref={activatorRef} setIsOpen={setModalIsOpen} />
+      <AssetModalEditActivator
+        ref={activatorRef}
+        asset={initialData}
+        isOpen={modalIsOpen}
+        setIsOpen={setModalIsOpen}
+      />
       <AssetModalBody
         ref={activatorRef}
         isOpen={modalIsOpen}
         setIsOpen={setModalIsOpen}
-        initialData={initialData}
       />
     </DropdownProvider>
   );

--- a/components/Portfolio/AssetModal/AssetModalWrapper.tsx
+++ b/components/Portfolio/AssetModal/AssetModalWrapper.tsx
@@ -42,6 +42,7 @@ const AssetModalWrapper = ({ role, initialData }: Props) => {
         isOpen={modalIsOpen}
         setIsOpen={setModalIsOpen}
       />
+
       <AssetModalBody
         ref={activatorRef}
         isOpen={modalIsOpen}

--- a/components/Portfolio/AssetModal/AssetModalWrapper.tsx
+++ b/components/Portfolio/AssetModal/AssetModalWrapper.tsx
@@ -1,29 +1,47 @@
 "use client";
 
-import { initializeNewDropdown } from "@/hooks/useDropdownStore";
-import { useRef, useState } from "react";
+import type { Asset } from "@/utils/types";
 
 import AssetModalAddActivator from "./AssetModalAddActivator";
+import AssetModalEditActivator from "./AssetModalEditActivator";
 import AssetModalBody from "./AssetModalBody";
 import DropdownProvider from "@/providers/DropdownProvider";
+
+import { useRef, useState } from "react";
+import { initializeNewDropdown } from "@/hooks/useDropdownStore";
 
 export const currencyDropdownId = "portfolioCurrency";
 export const searchDropdownId = "portfolioSearch";
 
-const AssetModalWrapper = () => {
+type Props = {
+  role: "add" | "edit";
+  initialData?: Asset;
+};
+
+const AssetModalWrapper = ({ role, initialData }: Props) => {
   const [modalIsOpen, setModalIsOpen] = useState<boolean>(false);
   const activatorRef = useRef<HTMLButtonElement>(null);
 
   const dropdownKeys = [searchDropdownId, currencyDropdownId];
   const dropdownUnits = dropdownKeys.map((key) => initializeNewDropdown(key));
 
-  return (
+  return role === "add" ? (
     <DropdownProvider initialUnits={dropdownUnits}>
       <AssetModalAddActivator ref={activatorRef} setIsOpen={setModalIsOpen} />
       <AssetModalBody
         ref={activatorRef}
         isOpen={modalIsOpen}
         setIsOpen={setModalIsOpen}
+      />
+    </DropdownProvider>
+  ) : (
+    <DropdownProvider initialUnits={dropdownUnits}>
+      <AssetModalEditActivator ref={activatorRef} setIsOpen={setModalIsOpen} />
+      <AssetModalBody
+        ref={activatorRef}
+        isOpen={modalIsOpen}
+        setIsOpen={setModalIsOpen}
+        initialData={initialData}
       />
     </DropdownProvider>
   );

--- a/components/Portfolio/Portfolio.tsx
+++ b/components/Portfolio/Portfolio.tsx
@@ -29,7 +29,7 @@ const Portfolio = () => {
         <div>
           <h2 className="text-4xl">Your Assets</h2>
         </div>
-        <AssetModalWrapper />
+        <AssetModalWrapper role="add" />
       </div>
       {assets.length === 0 && (
         <p className="italic mt-12 text-muted-foreground">No assets found.</p>

--- a/components/Portfolio/Portfolio.tsx
+++ b/components/Portfolio/Portfolio.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { extractDate } from "@/utils/extractDate";
+import { extractDate } from "@/utils/dateHelpers";
 import { sort } from "fast-sort";
-import { useAssetStore } from "@/hooks/useAssetStore";
+import { useAssetStore } from "@/hooks/useAssets";
 import {
   useAssetCurrentQueries,
   useAssetHistoryQueries,

--- a/hooks/useAssetModal.ts
+++ b/hooks/useAssetModal.ts
@@ -1,0 +1,83 @@
+import type { Currency } from "@/utils/types";
+
+import { create } from "zustand";
+// import { useUserCurrencySetting } from "./useUserSettings";
+
+type AssetModalState = {
+  assetId: string;
+  coinId: string;
+  coinQuery: string;
+  date: string;
+  value: string;
+  valueCurrency: Currency;
+
+  actions: AssetModalActions;
+};
+
+type AssetModalActions = {
+  setAssetId: (id: AssetModalState["assetId"]) => void;
+  setCoinId: (id: AssetModalState["coinId"]) => void;
+  setCoinQuery: (query: AssetModalState["coinQuery"]) => void;
+  setDate: (date: AssetModalState["date"]) => void;
+  setValue: (value: AssetModalState["value"]) => void;
+  setValueCurrency: (currency: AssetModalState["valueCurrency"]) => void;
+};
+
+export const defaultAssetModalProps: Omit<AssetModalState, "actions"> = {
+  assetId: "",
+  coinId: "",
+  coinQuery: "",
+  date: "",
+  value: "",
+  valueCurrency: "usd",
+};
+
+const useAssetModalStore = create<AssetModalState>((set) => {
+  //   const currency = useUserCurrencySetting();
+
+  return {
+    ...defaultAssetModalProps,
+    actions: {
+      setAssetId: (id) => set(() => ({ assetId: id })),
+      setCoinId: (id) => set(() => ({ coinId: id })),
+      setCoinQuery: (query) => set(() => ({ coinQuery: query })),
+      setDate: (date) => set(() => ({ date: date })),
+      setValue: (value) => set(() => ({ value: value })),
+      setValueCurrency: (currency) => set(() => ({ valueCurrency: currency })),
+    },
+  };
+});
+
+export const useAssetModalAssetId = () => {
+  return useAssetModalStore().assetId;
+};
+export const useAssetModalCoinId = () => {
+  return useAssetModalStore().coinId;
+};
+export const useAssetModalCoinQuery = () => {
+  return useAssetModalStore().coinQuery;
+};
+export const useAssetModalDate = () => {
+  return useAssetModalStore().date;
+};
+export const useAssetModalValue = () => {
+  return useAssetModalStore().value;
+};
+export const useAssetModalValueCurrency = () => {
+  return useAssetModalStore().valueCurrency;
+};
+
+export const useAssetModalActions = () => {
+  return useAssetModalStore().actions;
+};
+export const useAssetModalDefault = () => {
+  return () =>
+    useAssetModalStore.setState({
+      ...defaultAssetModalProps,
+    });
+};
+export const useAssetModalInjectData = (data: Partial<AssetModalState>) => {
+  const store = useAssetModalStore;
+  return () =>
+    store.setState({ ...defaultAssetModalProps, ...data });
+};

--- a/hooks/useAssetQueries.ts
+++ b/hooks/useAssetQueries.ts
@@ -19,7 +19,14 @@ export const useAssetHistoryQueries = (
     queries: assets.map(
       (asset) =>
         <UseQueryOptions>{
-          queryKey: ["asset", "history", asset.assetId],
+          // be sure to include the date in the query key;
+          // changes in value don't require a new api call but date changes do
+          queryKey: [
+            "asset",
+            "history",
+            asset.assetId,
+            asset.date,
+          ],
           queryFn: async (): Promise<AssetHistory> => {
             const response = await fetch(
               `${process.env.NEXT_PUBLIC_SERVER_URL}/api/v1/history`,
@@ -93,7 +100,7 @@ export const useAssetCurrentQueries = (
           refetchOnWindowFocus: false,
 
           // should refetch current data daily
-          staleTime: 1000 * 60 * 60 * 24
+          staleTime: 1000 * 60 * 60 * 24,
         }
     ),
   });

--- a/hooks/useAssetStore.ts
+++ b/hooks/useAssetStore.ts
@@ -22,8 +22,16 @@ export const useAssetStore = create<AssetStore>()(
 
 export const useAddAsset = () => {
   const assets = useAssetStore.getState().assets;
-  return (asset: Asset) =>
-    useAssetStore.setState({ assets: [...assets, asset] });
+  return (newAsset: Asset) => {
+    useAssetStore.setState({
+      assets: [
+        ...assets.filter(
+          (storedAsset) => storedAsset.assetId !== newAsset.assetId
+        ),
+        newAsset,
+      ],
+    });
+  };
 };
 
 export function validateAsset(asset: AssetValidator) {

--- a/hooks/useAssets.ts
+++ b/hooks/useAssets.ts
@@ -1,5 +1,6 @@
 import type { Asset, AssetValidator } from "@/utils/types";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { assetValidatorSchema } from "@/validation/schema";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
@@ -20,9 +21,30 @@ export const useAssetStore = create<AssetStore>()(
   )
 );
 
+export const useDeleteAsset = (deleteId: string, deleteDate: string) => {
+  const queryClient = useQueryClient();
+  return () => {
+    useAssetStore.setState((prev) => ({
+      assets: prev.assets.filter((asset) => asset.assetId !== deleteId),
+    }));
+
+    // clear asset data from the cache so it doesn't persist forever
+    queryClient.removeQueries({
+      queryKey: ["asset", "history", deleteId, deleteDate],
+      exact: true,
+    });
+    queryClient.removeQueries({
+      queryKey: ["asset", "current", deleteId],
+      exact: true,
+    });
+
+    toast.success("Asset deleted");
+  };
+};
+
 export const useUpdateAssets = () => {
   const assets = useAssetStore.getState().assets;
-  return (newAsset: Asset) => {
+  return (newAsset: Asset, editing: boolean) => {
     useAssetStore.setState({
       assets: [
         ...assets.filter(
@@ -31,6 +53,7 @@ export const useUpdateAssets = () => {
         newAsset,
       ],
     });
+    editing ? toast.success("Asset edited") : toast.success("Asset added");
   };
 };
 
@@ -40,7 +63,5 @@ export function validateAsset(asset: AssetValidator) {
     validation.error.errors.forEach((err) => toast.error(err.message));
     return false;
   }
-
-  toast.success("Asset added");
   return true;
 }

--- a/hooks/useAssets.ts
+++ b/hooks/useAssets.ts
@@ -1,4 +1,4 @@
-import type { Asset, AssetHistory, AssetValidator } from "@/utils/types";
+import type { Asset, AssetValidator } from "@/utils/types";
 
 import { assetValidatorSchema } from "@/validation/schema";
 import { create } from "zustand";
@@ -20,7 +20,7 @@ export const useAssetStore = create<AssetStore>()(
   )
 );
 
-export const useAddAsset = () => {
+export const useUpdateAssets = () => {
   const assets = useAssetStore.getState().assets;
   return (newAsset: Asset) => {
     useAssetStore.setState({

--- a/hooks/useModalListener.ts
+++ b/hooks/useModalListener.ts
@@ -18,7 +18,7 @@ export const useModalListener = (
 ) =>
   useEffect(() => {
     const handleModalExit = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && dropdownRefs?.every((ref) => !ref.current))
+      if (isOpen && e.key === "Escape" && dropdownRefs?.every((ref) => !ref.current))
         handleExit();
     };
     document.addEventListener("keydown", handleModalExit);

--- a/utils/convertHistoricalDate.ts
+++ b/utils/convertHistoricalDate.ts
@@ -1,3 +1,0 @@
-export function convertHistoricalDate(date: Date) {
-  return date.toLocaleDateString("en-GB").replaceAll("/", "-");
-}

--- a/utils/dateHelpers.ts
+++ b/utils/dateHelpers.ts
@@ -8,7 +8,7 @@ export function extractDate(date: string) {
 
 /**
  * The input date is using UTC at midnight, but the date shown to the user should be in the user's locale.
- * If we just convert to a locale string without accounting for this, the date will go down a day if the time zone is a positive shift.
+ * If we just convert to a locale string without accounting for this, the date will go down a day if the time zone shifts back from UTC.
  */
 export function convertHistoricalDate(date: Date) {
   return new Date(date.valueOf() + date.getTimezoneOffset() * 60 * 1000)

--- a/utils/dateHelpers.ts
+++ b/utils/dateHelpers.ts
@@ -7,7 +7,8 @@ export function extractDate(date: string) {
 }
 
 /**
- *
+ * The input date is using UTC at midnight, but the date shown to the user should be in the user's locale.
+ * If we just convert to a locale string without accounting for this, the date will go down a day if the time zone is a positive shift.
  */
 export function convertHistoricalDate(date: Date) {
   return new Date(date.valueOf() + date.getTimezoneOffset() * 60 * 1000)

--- a/utils/dateHelpers.ts
+++ b/utils/dateHelpers.ts
@@ -1,0 +1,32 @@
+/**
+ * Generates a new date object given the string following the API format DD-MM-YYYY
+ */
+export function extractDate(date: string) {
+  const [day, month, year] = date.split("-");
+  return new Date(parseInt(year), parseInt(month) - 1, parseInt(day));
+}
+
+/**
+ *
+ */
+export function convertHistoricalDate(date: Date) {
+  return new Date(date.valueOf() + date.getTimezoneOffset() * 60 * 1000)
+    .toLocaleDateString("en-GB")
+    .replaceAll("/", "-");
+}
+
+/**
+ * The date input is stored internally as YYYY-MM-DD, but the coingecko API needs the form DD-MM-YYYY
+ */
+export function swapDateApiToInput(apiDate: string) {
+  const [day, month, year] = apiDate.split("-");
+  return [year, month, day].join("-");
+}
+
+/**
+ *
+ */
+export function lastYear() {
+  const date = new Date();
+  return new Date(date.valueOf() - 1000 * 60 * 60 * 24 * 365);
+}

--- a/utils/extractDate.ts
+++ b/utils/extractDate.ts
@@ -1,7 +1,0 @@
-/**
- * Generates a new date object from the API format of DD-MM-YYYY
- */
-export function extractDate(dateStr: string) {
-  const [day, month, year] = dateStr.split("-");
-  return new Date(parseInt(year), parseInt(month) - 1, parseInt(day) + 1);
-}

--- a/utils/lastYear.ts
+++ b/utils/lastYear.ts
@@ -1,4 +1,0 @@
-export function lastYear() {
-  const date = new Date();
-  return new Date(date.valueOf() - 1000 * 60 * 60 * 24 * 365);
-}

--- a/validation/schema.ts
+++ b/validation/schema.ts
@@ -1,4 +1,4 @@
-import { lastYear } from "@/utils/lastYear";
+import { lastYear } from "@/utils/dateHelpers";
 import { z } from "zod";
 
 export const currenciesUnionSchema = z.union([


### PR DESCRIPTION
- Assets can now be edited and deleted
- Creates a central store to save modal state; reset when modal is exited and injected with data when editing is needed
- Asset valuation changes will not trigger another api call, only purchase date changes

https://github.com/agreen254/crypto-app/assets/101513222/72aa4a3e-2e66-4db0-a99d-35e2f8002545

